### PR TITLE
fix: temporarily disable xone kmod build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,7 +18,8 @@ RUN /tmp/build-ublue-os-akmods-addons.sh
 
 RUN /tmp/build-kmod-v4l2loopback.sh
 RUN /tmp/build-kmod-wl.sh
-RUN /tmp/build-kmod-xone.sh
+# disabled until has kernel 6.3 support
+#RUN /tmp/build-kmod-xone.sh
 RUN /tmp/build-kmod-xpadneo.sh
 
 RUN mkdir -p /var/cache/rpms/{kmods,ublue-os}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Feel free to PR more kmod build scripts into this repo!
 - ublue-os-akmods-addons - installs extra repos and our kmods signing key; install and import to allow SecureBoot systems to use these kmods
 - [v4l2loopback](https://github.com/umlaeute/v4l2loopback) - allows creating "virtual video devices"
 - [wl (broadcom)](https://github.com/rpmfusion/broadcom-wl/) - support for some legacy broadcom wifi devices
-- [xone](https://github.com/medusalix/xone) - xbox one controller USB wired/RF driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)
+- Temporarily Disabled pending kernel 6.3 support *[xone](https://github.com/medusalix/xone) - xbox one controller USB wired/RF driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)*
 - [xpadneo](https://github.com/atar-axis/xpadneo) - xbox one controller bluetooth driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)
 
 # Adding kmods


### PR DESCRIPTION
Upstream provider of the xone akmod is using the latest release of xone which does not yet have support for kernel 6.3. Temporarily disabling until xone releases their 6.3 fix in order to unblock builds.