### PR TITLE
Revert "fix: temporarily disable xone kmod build"

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,8 +17,7 @@ RUN /tmp/build-prep.sh
 RUN /tmp/build-ublue-os-akmods-addons.sh
 
 RUN /tmp/build-kmod-v4l2loopback.sh
-# disabled until has kernel 6.3 support
-#RUN /tmp/build-kmod-xone.sh
+RUN /tmp/build-kmod-xone.sh
 RUN /tmp/build-kmod-xpadneo.sh
 
 RUN mkdir -p /var/cache/rpms/{kmods,ublue-os}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Feel free to PR more kmod build scripts into this repo!
 
 - ublue-os-akmods-addons - installs extra repos and our kmods signing key; install and import to allow SecureBoot systems to use these kmods
 - [v4l2loopback](https://github.com/umlaeute/v4l2loopback) - allows creating "virtual video devices"
-- Temporarily Disabled pending kernel 6.3 support *[xone](https://github.com/medusalix/xone) - xbox one controller USB wired/RF driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)*
+- [xone](https://github.com/medusalix/xone) - xbox one controller USB wired/RF driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)
 - [xpadneo](https://github.com/atar-axis/xpadneo) - xbox one controller bluetooth driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)
 
 # Adding kmods


### PR DESCRIPTION
xone now has support for kernel 6.3.x

This reverts commit 76806adc856db2163c188125ba7546362282cee2.