### PR TITLE
fix: disable xone until as it disables too many controllers

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,6 @@ RUN /tmp/build-prep.sh
 RUN /tmp/build-ublue-os-akmods-addons.sh
 
 RUN /tmp/build-kmod-v4l2loopback.sh
-RUN /tmp/build-kmod-xone.sh
 RUN /tmp/build-kmod-xpadneo.sh
 
 RUN mkdir -p /var/cache/rpms/{kmods,ublue-os}

--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ Feel free to PR more kmod build scripts into this repo!
 
 - ublue-os-akmods-addons - installs extra repos and our kmods signing key; install and import to allow SecureBoot systems to use these kmods
 - [v4l2loopback](https://github.com/umlaeute/v4l2loopback) - allows creating "virtual video devices"
-- [xone](https://github.com/medusalix/xone) - xbox one controller USB wired/RF driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)
 - [xpadneo](https://github.com/atar-axis/xpadneo) - xbox one controller bluetooth driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)
+
+Temporarily disabled due to disabling other controllers:
+- [xone](https://github.com/medusalix/xone) - xbox one controller USB wired/RF driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)
 
 # Adding kmods
 


### PR DESCRIPTION
Until we can add `xpad-noone` we need `xone` disabled. This removes support for Xbox One RF dongle, but does prevent the disabling of lots of other hardware. It's the right choice for now.

Fixes #25 