### PR TITLE
feat: Add Google Coral TPU driver (gasket & apex) akmod

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -23,6 +23,7 @@ RUN /tmp/build-kmod-v4l2loopback.sh
 RUN /tmp/build-kmod-xpadneo.sh
 RUN /tmp/build-kmod-steamdeck.sh
 RUN /tmp/build-kmod-gcadapter_oc.sh
+RUN /tmp/build-kmod-gasket.sh
 
 RUN mkdir -p /var/cache/rpms/{kmods,ublue-os}
 RUN cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm \

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The rpmfusion and extra repos provide dependencies which are required by the kmo
 Feel free to PR more kmod build scripts into this repo!
 
 - ublue-os-akmods-addons - installs extra repos and our kmods signing key; install and import to allow SecureBoot systems to use these kmods
+- [gasket](https://github.com/google/gasket-driver) - kernel module for Coral Gasket Driver, allowing usage of the Coral EdgeTPU on Linux systems.
 - [gcadapter_oc](https://github.com/hannesmann/gcadapter-oc-kmod) - kernel module for overclocking the Nintendo Wii U/Mayflash GameCube adapter (akmod from [copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [steamdeck](https://lkml.org/lkml/2022/2/5/391) - platform driver for Valve's Steam Deck handheld PC (akmod from [copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [v4l2loopback](https://github.com/umlaeute/v4l2loopback) - allows creating "virtual video devices"

--- a/build-kmod-gasket.sh
+++ b/build-kmod-gasket.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+rpm-ostree install \
+    akmod-gasket-*.fc${RELEASE}.${ARCH}
+akmods --force --kernels "${KERNEL}" --kmod gasket
+modinfo /usr/lib/modules/${KERNEL}/extra/gasket/{gasket,apex}.ko.xz > /dev/null \
+|| (find /var/cache/akmods/gasket/ -name \*.log -print -exec cat {} \; && exit 1)
+
+rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo


### PR DESCRIPTION
Driver needed for Google's Coral TPU hardware on Linux, useful for home servers since it can do ML image processing at very low power usage.

https://coral.ai/products/

Version actually being built here is at https://github.com/KyleGospo/gasket-dkms
We could build upstream, however it has issues preventing it from being unloaded and a few other bugs fixed downstream at OpenSUSE among other places, so this repo serves as a patched source.