### PR TITLE
fix: Switch to building jupiter driver instead of steamdeck

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,7 +21,7 @@ RUN /tmp/build-ublue-os-akmods-addons.sh
 
 RUN /tmp/build-kmod-v4l2loopback.sh
 RUN /tmp/build-kmod-xpadneo.sh
-RUN /tmp/build-kmod-steamdeck.sh
+RUN /tmp/build-kmod-jupiter.sh
 RUN /tmp/build-kmod-gcadapter_oc.sh
 
 RUN mkdir -p /var/cache/rpms/{kmods,ublue-os}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Feel free to PR more kmod build scripts into this repo!
 
 - ublue-os-akmods-addons - installs extra repos and our kmods signing key; install and import to allow SecureBoot systems to use these kmods
 - [gcadapter_oc](https://github.com/hannesmann/gcadapter-oc-kmod) - kernel module for overclocking the Nintendo Wii U/Mayflash GameCube adapter (akmod from [copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
-- [steamdeck](https://lkml.org/lkml/2022/2/5/391) - platform driver for Valve's Steam Deck handheld PC (akmod from [copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
+- [jupiter](https://lkml.org/lkml/2022/2/5/391) - platform driver for Valve's Steam Deck handheld PC (akmod from [copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [v4l2loopback](https://github.com/umlaeute/v4l2loopback) - allows creating "virtual video devices"
 - [xpadneo](https://github.com/atar-axis/xpadneo) - xbox one controller bluetooth driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)
 

--- a/build-kmod-jupiter.sh
+++ b/build-kmod-jupiter.sh
@@ -9,9 +9,9 @@ KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
 rpm-ostree install \
-    akmod-steamdeck-*.fc${RELEASE}.${ARCH}
-akmods --force --kernels "${KERNEL}" --kmod steamdeck
-modinfo /usr/lib/modules/${KERNEL}/extra/steamdeck/steamdeck.ko.xz > /dev/null \
-|| (find /var/cache/akmods/steamdeck/ -name \*.log -print -exec cat {} \; && exit 1)
+    akmod-jupiter-*.fc${RELEASE}.${ARCH}
+akmods --force --kernels "${KERNEL}" --kmod jupiter
+modinfo /usr/lib/modules/${KERNEL}/extra/jupiter/jupiter.ko.xz > /dev/null \
+|| (find /var/cache/akmods/jupiter/ -name \*.log -print -exec cat {} \; && exit 1)
 
 rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo


### PR DESCRIPTION
Jupiter is what Valve shipped with SteamOS, steamdeck is what they submitted upstream. Same driver, but all of Valve's packages point to the name jupiter (or steamdeck-hwmon on main), rendering it useless for it's intended purpose.