### PR TITLE
feat: Add vangogh_oc_fix driver.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,6 +22,7 @@ RUN /tmp/build-ublue-os-akmods-addons.sh
 RUN /tmp/build-kmod-v4l2loopback.sh
 RUN /tmp/build-kmod-xpadneo.sh
 RUN /tmp/build-kmod-steamdeck.sh
+RUN /tmp/build-kmod-vangogh_oc_fix.sh
 RUN /tmp/build-kmod-gcadapter_oc.sh
 
 RUN mkdir -p /var/cache/rpms/{kmods,ublue-os}

--- a/build-kmod-vangogh_oc_fix.sh
+++ b/build-kmod-vangogh_oc_fix.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+rpm-ostree install \
+    akmod-vangogh_oc_fix-*.fc${RELEASE}.${ARCH}
+akmods --force --kernels "${KERNEL}" --kmod vangogh_oc_fix
+modinfo /usr/lib/modules/${KERNEL}/extra/vangogh_oc_fix/vangogh_oc_fix.ko.xz > /dev/null \
+|| (find /var/cache/akmods/vangogh_oc_fix/ -name \*.log -print -exec cat {} \; && exit 1)
+
+rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo


### PR DESCRIPTION
Driver for exceeding Powerplay limits on AMD's VanGogh APU.

No modules.load.d entry is provided with this kmod due to the inherit risk of it's use.