### PR TITLE
feat: Add Google Coral TPU Gasket & Apex drivers

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,10 +19,10 @@ RUN /tmp/build-prep.sh
 
 RUN /tmp/build-ublue-os-akmods-addons.sh
 
+RUN /tmp/build-kmod-gcadapter_oc.sh
+RUN /tmp/build-kmod-steamdeck.sh
 RUN /tmp/build-kmod-v4l2loopback.sh
 RUN /tmp/build-kmod-xpadneo.sh
-RUN /tmp/build-kmod-steamdeck.sh
-RUN /tmp/build-kmod-gcadapter_oc.sh
 
 RUN mkdir -p /var/cache/rpms/{kmods,ublue-os}
 RUN cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm \

--- a/Containerfile
+++ b/Containerfile
@@ -19,6 +19,7 @@ RUN /tmp/build-prep.sh
 
 RUN /tmp/build-ublue-os-akmods-addons.sh
 
+RUN /tmp/build-kmod-gasket.sh
 RUN /tmp/build-kmod-gcadapter_oc.sh
 RUN /tmp/build-kmod-steamdeck.sh
 RUN /tmp/build-kmod-v4l2loopback.sh

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ The rpmfusion and extra repos provide dependencies which are required by the kmo
 Feel free to PR more kmod build scripts into this repo!
 
 - ublue-os-akmods-addons - installs extra repos and our kmods signing key; install and import to allow SecureBoot systems to use these kmods
-- [gcadapter_oc](https://github.com/hannesmann/gcadapter-oc-kmod) - kernel module for overclocking the Nintendo Wii U/Mayflash GameCube adapter (akmod from [copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
-- [steamdeck](https://lkml.org/lkml/2022/2/5/391) - platform driver for Valve's Steam Deck handheld PC (akmod from [copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
+- [gasket/apex](https://github.com/google/gasket-driver) - kernel module for Coral Gasket Driver, allowing usage of the Coral EdgeTPU on Linux systems (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
+- [gcadapter_oc](https://github.com/hannesmann/gcadapter-oc-kmod) - kernel module for overclocking the Nintendo Wii U/Mayflash GameCube adapter (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
+- [steamdeck](https://lkml.org/lkml/2022/2/5/391) - platform driver for Valve's Steam Deck handheld PC (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [v4l2loopback](https://github.com/umlaeute/v4l2loopback) - allows creating "virtual video devices"
 - [xpadneo](https://github.com/atar-axis/xpadneo) - xbox one controller bluetooth driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Feel free to PR more kmod build scripts into this repo!
 
 - ublue-os-akmods-addons - installs extra repos and our kmods signing key; install and import to allow SecureBoot systems to use these kmods
 - [gcadapter_oc](https://github.com/hannesmann/gcadapter-oc-kmod) - kernel module for overclocking the Nintendo Wii U/Mayflash GameCube adapter (akmod from [copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
-- [jupiter](https://lkml.org/lkml/2022/2/5/391) - platform driver for Valve's Steam Deck handheld PC (akmod from [copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
+- [steamdeck](https://lkml.org/lkml/2022/2/5/391) - platform driver for Valve's Steam Deck handheld PC (akmod from [copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [v4l2loopback](https://github.com/umlaeute/v4l2loopback) - allows creating "virtual video devices"
 - [xpadneo](https://github.com/atar-axis/xpadneo) - xbox one controller bluetooth driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)
 

--- a/build-kmod-gasket.sh
+++ b/build-kmod-gasket.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+rpm-ostree install \
+    akmod-gasket-*.fc${RELEASE}.${ARCH}
+akmods --force --kernels "${KERNEL}" --kmod gasket
+modinfo /usr/lib/modules/${KERNEL}/extra/gasket/{gasket,apex}.ko.xz > /dev/null \
+|| (find /var/cache/akmods/gasket/ -name \*.log -print -exec cat {} \; && exit 1)
+
+rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo


### PR DESCRIPTION
Driver needed for Google's Coral TPU hardware on Linux, useful for home servers since it can do ML image processing at very low power usage.

https://coral.ai/products/

Version actually being built here is at https://github.com/KyleGospo/gasket-dkms
We could build upstream, however it has issues preventing it from being unloaded and a few other bugs fixed downstream at OpenSUSE among other places, so this repo serves as a patched source.