### PR TITLE
feat: Add OpenRGB kernel modules

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,6 +21,7 @@ RUN /tmp/build-ublue-os-akmods-addons.sh
 
 RUN /tmp/build-kmod-gasket.sh
 RUN /tmp/build-kmod-gcadapter_oc.sh
+RUN /tmp/build-kmod-openrgb.sh
 RUN /tmp/build-kmod-steamdeck.sh
 RUN /tmp/build-kmod-v4l2loopback.sh
 RUN /tmp/build-kmod-xpadneo.sh

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Feel free to PR more kmod build scripts into this repo!
 - ublue-os-akmods-addons - installs extra repos and our kmods signing key; install and import to allow SecureBoot systems to use these kmods
 - [gasket/apex](https://github.com/google/gasket-driver) - kernel module for Coral Gasket Driver, allowing usage of the Coral EdgeTPU on Linux systems (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [gcadapter_oc](https://github.com/hannesmann/gcadapter-oc-kmod) - kernel module for overclocking the Nintendo Wii U/Mayflash GameCube adapter (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
+- [openrgb](https://gitlab.com/CalcProgrammer1/OpenRGB/-/raw/master/OpenRGB.patch) - kernel module with i2c-nct6775 and patched i2c-piix4 for use with OpenRGB (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [steamdeck](https://lkml.org/lkml/2022/2/5/391) - platform driver for Valve's Steam Deck handheld PC (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [v4l2loopback](https://github.com/umlaeute/v4l2loopback) - allows creating "virtual video devices"
 - [xpadneo](https://github.com/atar-axis/xpadneo) - xbox one controller bluetooth driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)

--- a/build-kmod-openrgb.sh
+++ b/build-kmod-openrgb.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+rpm-ostree install \
+    akmod-openrgb-*.fc${RELEASE}.${ARCH}
+akmods --force --kernels "${KERNEL}" --kmod openrgb
+modinfo /usr/lib/modules/${KERNEL}/extra/openrgb/i2c-{piix4,nct6775}.ko.xz > /dev/null \
+|| (find /var/cache/akmods/openrgb/ -name \*.log -print -exec cat {} \; && exit 1)
+
+rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo


### PR DESCRIPTION
Provides modified i2c-piix4 and new i2c-nct6775 for controlling RGB on certain motherboards.