### PR TITLE
Revert "Merge pull request #20 from EyeCantCU/rm-wl"

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -24,6 +24,7 @@ RUN /tmp/build-kmod-gcadapter_oc.sh
 RUN /tmp/build-kmod-openrgb.sh
 RUN /tmp/build-kmod-steamdeck.sh
 RUN /tmp/build-kmod-v4l2loopback.sh
+RUN /tmp/build-kmod-wl.sh
 RUN /tmp/build-kmod-xpadneo.sh
 
 RUN mkdir -p /var/cache/rpms/{kmods,ublue-os}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Feel free to PR more kmod build scripts into this repo!
 - [openrgb](https://gitlab.com/CalcProgrammer1/OpenRGB/-/raw/master/OpenRGB.patch) - kernel module with i2c-nct6775 and patched i2c-piix4 for use with OpenRGB (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [steamdeck](https://lkml.org/lkml/2022/2/5/391) - platform driver for Valve's Steam Deck handheld PC (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [v4l2loopback](https://github.com/umlaeute/v4l2loopback) - allows creating "virtual video devices"
+- [wl (broadcom)](https://github.com/rpmfusion/broadcom-wl/) - support for some legacy broadcom wifi devices
 - [xpadneo](https://github.com/atar-axis/xpadneo) - xbox one controller bluetooth driver (akmod from [negativo17 steam repo](https://negativo17.org/steam/)
 
 Temporarily disabled due to disabling other controllers:

--- a/build-kmod-wl.sh
+++ b/build-kmod-wl.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+
+### BUILD wl (succeed or fail-fast with debug output)
+rpm-ostree install \
+    akmod-wl-*.fc${RELEASE}.${ARCH}
+akmods --force --kernels "${KERNEL}" --kmod wl
+modinfo /usr/lib/modules/${KERNEL}/extra/wl/wl.ko.xz > /dev/null \
+|| (find /var/cache/akmods/wl/ -name \*.log -print -exec cat {} \; && exit 1)


### PR DESCRIPTION
This reverts commit 697d57ca8ab0a29b217a6674862bd61bfeec628d, reversing changes made to 4606c64da29576f6f2cea8a1a97d82f18485895f.

This restores the kmod build for the `wl` legacy broadcom driver.  We can do this because of the PR to main https://github.com/ublue-os/main/pull/278 which only includes specific modules in `ublue-os/*-main` images.

By restoring this build, downstream users have the option to include the module if required.