### PR TITLE
feat: Add evdi kmod for displaylink

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,10 +15,14 @@ ADD https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-${FEDORA
 ADD https://negativo17.org/repos/fedora-steam.repo \
     /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-steam.repo
 
+ADD https://negativo17.org/repos/fedora-multimedia.repo \
+    /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo    
+
 RUN /tmp/build-prep.sh
 
 RUN /tmp/build-ublue-os-akmods-addons.sh
 
+RUN /tmp/build-kmod-evdi.sh
 RUN /tmp/build-kmod-gasket.sh
 RUN /tmp/build-kmod-gcadapter_oc.sh
 RUN /tmp/build-kmod-openrgb.sh

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The rpmfusion and extra repos provide dependencies which are required by the kmo
 Feel free to PR more kmod build scripts into this repo!
 
 - ublue-os-akmods-addons - installs extra repos and our kmods signing key; install and import to allow SecureBoot systems to use these kmods
+- [evdi](www.displaylink.com) - kernel module required for use of displaylink (akmod from [negativo17 multimedia repo](https://negativo17.org/multimedia/)
 - [gasket/apex](https://github.com/google/gasket-driver) - kernel module for Coral Gasket Driver, allowing usage of the Coral EdgeTPU on Linux systems (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [gcadapter_oc](https://github.com/hannesmann/gcadapter-oc-kmod) - kernel module for overclocking the Nintendo Wii U/Mayflash GameCube adapter (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [openrgb](https://gitlab.com/CalcProgrammer1/OpenRGB/-/raw/master/OpenRGB.patch) - kernel module with i2c-nct6775 and patched i2c-piix4 for use with OpenRGB (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))

--- a/build-kmod-evdi.sh
+++ b/build-kmod-evdi.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo /etc/yum.repos.d/
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+
+### BUILD evdi (succeed or fail-fast with debug output)
+export CFLAGS="-fno-pie -no-pie"
+rpm-ostree install \
+    akmod-evdi-*.fc${RELEASE}.${ARCH}
+akmods --force --kernels "${KERNEL}" --kmod evdi
+modinfo /usr/lib/modules/${KERNEL}/extra/evdi/evdi.ko.xz > /dev/null \
+|| (find /var/cache/akmods/evdi/ -name \*.log -print -exec cat {} \; && exit 1)
+
+rm -f /etc/yum.repos.d/negativo17-fedora-multimedia.repo
+unset CFLAGS


### PR DESCRIPTION
Required for use of the [displaylink](https://www.synaptics.com/products/displaylink-graphics) display standard.