### PR TITLE
feat: enable builds with Fedora 39

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         cfile_suffix: [common, nvidia]
-        major_version: [37, 38]
+        major_version: [37, 38, 39]
         nvidia_version: [0, 470, 535]
         exclude:
           - cfile_suffix: common

--- a/Containerfile.common
+++ b/Containerfile.common
@@ -37,7 +37,7 @@ RUN /tmp/build-kmod-v4l2loopback.sh
 RUN /tmp/build-kmod-wl.sh
 
 # Exclude negativo17 kmods from Fedora 39
-RUN if grep -q ${FEDORA_MAJOR_VERSION}; then \
+RUN if grep -qv "39" <<< ${FEDORA_MAJOR_VERSION}; then \
         /tmp/build-kmod-evdi.sh && \
         /tmp/build-kmod-xpadneo.sh && \
         /tmp/build-kmod-xpad-noone.sh && \

--- a/Containerfile.common
+++ b/Containerfile.common
@@ -26,7 +26,6 @@ RUN /tmp/build-prep.sh
 
 RUN /tmp/build-ublue-os-akmods-addons.sh
 
-RUN /tmp/build-kmod-evdi.sh
 RUN /tmp/build-kmod-gasket.sh
 RUN /tmp/build-kmod-gcadapter_oc.sh
 RUN /tmp/build-kmod-nct6687d.sh
@@ -36,9 +35,14 @@ RUN /tmp/build-kmod-ryzen-smu.sh
 RUN /tmp/build-kmod-steamdeck.sh
 RUN /tmp/build-kmod-v4l2loopback.sh
 RUN /tmp/build-kmod-wl.sh
-RUN /tmp/build-kmod-xpadneo.sh
-RUN /tmp/build-kmod-xpad-noone.sh
-RUN /tmp/build-kmod-xone.sh
+
+# Exclude negativo17 kmods from Fedora 39
+RUN if grep -q ${FEDORA_MAJOR_VERSION}; then \
+        /tmp/build-kmod-evdi.sh && \
+        /tmp/build-kmod-xpadneo.sh && \
+        /tmp/build-kmod-xpad-noone.sh && \
+        /tmp/build-kmod-xone.sh \
+    ; fi
 
 RUN cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm \
       /var/cache/rpms/ublue-os/

--- a/build-prep.sh
+++ b/build-prep.sh
@@ -7,8 +7,12 @@ set -oeux pipefail
 ARCH="$(rpm -E '%_arch')"
 RELEASE="$(rpm -E '%fedora')"
 
-
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-{cisco-openh264,modular,updates-modular}.repo
+# Modularity repositories are not available on Fedora 39 and above, so don't try to disable them
+if [[ "${FEDORA_VERSION}" -le 38 ]]; then
+    sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-{cisco-openh264,modular,updates-modular}.repo
+else
+    sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
+fi
 
 # enable RPMs with alternatives to create them in this image build
 mkdir -p /var/lib/alternatives

--- a/build-prep.sh
+++ b/build-prep.sh
@@ -8,7 +8,7 @@ ARCH="$(rpm -E '%_arch')"
 RELEASE="$(rpm -E '%fedora')"
 
 # Modularity repositories are not available on Fedora 39 and above, so don't try to disable them
-if [[ "${FEDORA_VERSION}" -le 38 ]]; then
+if [[ "${FEDORA_MAJOR_VERSION}" -le 38 ]]; then
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-{cisco-openh264,modular,updates-modular}.repo
 else
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo


### PR DESCRIPTION
An experiment to see how much we need to change for Fedora 39.
The images are now being pushed to Quay for base and silverblue.

I am not expecting many packages to build.  This is just an experiment.