### PR TITLE
feat: add nvidia kmod builds and ublue-os-nvidia-addons

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,23 +4,37 @@ ARG BASE_IMAGE="quay.io/fedora-ostree-desktops/${SOURCE_IMAGE}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-37}"
 
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS builder
-RUN ln -s /usr/bin/rpm-ostree /usr/bin/dnf
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-37}"
+
 COPY build*.sh /tmp
 COPY certs /tmp/certs
-COPY ublue-os-akmods-addons.spec /tmp/ublue-os-akmods-addons/ublue-os-akmods-addons.spec
 
+# files for akmods
+COPY ublue-os-akmods-addons.spec /tmp/ublue-os-akmods-addons/ublue-os-akmods-addons.spec
 ADD https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-${FEDORA_MAJOR_VERSION}/ublue-os-akmods-fedora-${FEDORA_MAJOR_VERSION}.repo \
     /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo
-
 ADD https://negativo17.org/repos/fedora-steam.repo \
     /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-steam.repo
-
 ADD https://negativo17.org/repos/fedora-multimedia.repo \
     /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo    
+
+# files for nvidia
+COPY ublue-os-nvidia-addons.spec /tmp/ublue-os-nvidia-addons/ublue-os-nvidia-addons.spec
+ADD https://nvidia.github.io/nvidia-docker/rhel9.0/nvidia-docker.repo \
+    /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/nvidia-container-runtime.repo
+ADD https://copr.fedorainfracloud.org/coprs/eyecantcu/supergfxctl/repo/fedora-${FEDORA_MAJOR_VERSION}/eyecantcu-supergfxctl-fedora-${FEDORA_MAJOR_VERSION}.repo \
+    /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/eyecantcu-supergfxctl.repo
+ADD files/etc/nvidia-container-runtime/config-rootless.toml \
+    /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/config-rootless.toml
+ADD https://raw.githubusercontent.com/NVIDIA/dgx-selinux/master/bin/RHEL9/nvidia-container.pp \
+    /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/nvidia-container.pp
+ADD files/etc/sway/environment /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/environment
+
 
 RUN /tmp/build-prep.sh
 
 RUN /tmp/build-ublue-os-akmods-addons.sh
+RUN /tmp/build-ublue-os-nvidia-addons.sh
 
 RUN /tmp/build-kmod-evdi.sh
 RUN /tmp/build-kmod-gasket.sh
@@ -30,10 +44,12 @@ RUN /tmp/build-kmod-steamdeck.sh
 RUN /tmp/build-kmod-v4l2loopback.sh
 RUN /tmp/build-kmod-wl.sh
 RUN /tmp/build-kmod-xpadneo.sh
+RUN /tmp/build-kmod-nvidia.sh 470
+RUN /tmp/build-kmod-nvidia.sh 535
 
-RUN mkdir -p /var/cache/rpms/{kmods,ublue-os}
 RUN cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm \
-        /var/cache/rpms/ublue-os/
+       /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons*.rpm \
+      /var/cache/rpms/ublue-os/
 RUN for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
         cp "${RPM}" /var/cache/rpms/kmods/; \
     done

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Feel free to PR more kmod build scripts into this repo!
 - [evdi](www.displaylink.com) - kernel module required for use of displaylink (akmod from [negativo17 multimedia repo](https://negativo17.org/multimedia/)
 - [gasket/apex](https://github.com/google/gasket-driver) - kernel module for Coral Gasket Driver, allowing usage of the Coral EdgeTPU on Linux systems (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [gcadapter_oc](https://github.com/hannesmann/gcadapter-oc-kmod) - kernel module for overclocking the Nintendo Wii U/Mayflash GameCube adapter (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
+- [nvidia](https://rpmfusion.org/Howto/NVIDIA) - nvidia GPU drivers built from rpmfusion
 - [openrgb](https://gitlab.com/CalcProgrammer1/OpenRGB/-/raw/master/OpenRGB.patch) - kernel module with i2c-nct6775 and patched i2c-piix4 for use with OpenRGB (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [steamdeck](https://lkml.org/lkml/2022/2/5/391) - platform driver for Valve's Steam Deck handheld PC (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [v4l2loopback](https://github.com/umlaeute/v4l2loopback) - allows creating "virtual video devices"

--- a/build-kmod-nvidia.sh
+++ b/build-kmod-nvidia.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+NVIDIA_MAJOR_VERSION=${1}
+
+RELEASE="$(rpm -E '%fedora.%_arch')"
+echo NVIDIA_MAJOR_VERSION=${NVIDIA_MAJOR_VERSION}
+
+cd /tmp
+
+### BUILD nvidia
+# nvidia 520.xxx and newer currently don't have a -$VERSIONxx suffix in their
+# package names
+if [[ "${NVIDIA_MAJOR_VERSION}" -ge 520 ]]; then
+    NVIDIA_PACKAGE_NAME="nvidia"
+else
+    NVIDIA_PACKAGE_NAME="nvidia-${NVIDIA_MAJOR_VERSION}xx"
+fi
+
+dnf install -y \
+    akmod-${NVIDIA_PACKAGE_NAME}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE} \
+    xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-{,cuda,devel,kmodsrc,power}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE}
+
+# Either successfully build and install the kernel modules, or fail early with debug output
+KERNEL_VERSION="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+NVIDIA_AKMOD_VERSION="$(basename "$(rpm -q "akmod-${NVIDIA_PACKAGE_NAME}" --queryformat '%{VERSION}-%{RELEASE}')" ".fc${RELEASE%%.*}")"
+NVIDIA_LIB_VERSION="$(basename "$(rpm -q "xorg-x11-drv-${NVIDIA_PACKAGE_NAME}" --queryformat '%{VERSION}-%{RELEASE}')" ".fc${RELEASE%%.*}")"
+NVIDIA_FULL_VERSION="$(rpm -q "xorg-x11-drv-${NVIDIA_PACKAGE_NAME}" --queryformat '%{EPOCH}:%{VERSION}-%{RELEASE}.%{ARCH}')"
+
+
+akmods --force --kernels "${KERNEL_VERSION}" --kmod "${NVIDIA_PACKAGE_NAME}"
+
+modinfo /usr/lib/modules/${KERNEL_VERSION}/extra/${NVIDIA_PACKAGE_NAME}/nvidia{,-drm,-modeset,-peermem,-uvm}.ko.xz > /dev/null || \
+(cat /var/cache/akmods/${NVIDIA_PACKAGE_NAME}/${NVIDIA_AKMOD_VERSION}-for-${KERNEL_VERSION}.failed.log && exit 1)
+
+cat <<EOF > /var/cache/rpms/kmods/nvidia-vars.${NVIDIA_MAJOR_VERSION}
+KERNEL_VERSION=${KERNEL_VERSION}
+RELEASE=${RELEASE}
+NVIDIA_PACKAGE_NAME=${NVIDIA_PACKAGE_NAME}
+NVIDIA_MAJOR_VERSION=${NVIDIA_MAJOR_VERSION}
+NVIDIA_FULL_VERSION=${NVIDIA_FULL_VERSION}
+NVIDIA_AKMOD_VERSION=${NVIDIA_AKMOD_VERSION}
+NVIDIA_LIB_VERSION=${NVIDIA_LIB_VERSION}
+EOF
+
+# cleanup for other nvidia builds
+dnf remove -y \
+    akmod-${NVIDIA_PACKAGE_NAME}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE} \
+    xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-{,cuda,devel,kmodsrc,power}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE}

--- a/build-prep.sh
+++ b/build-prep.sh
@@ -24,6 +24,7 @@ rpm-ostree install \
 ### PREPARE BUILD ENV
 rpm-ostree install \
     akmods \
+    dnf \
     mock
 
 if [[ ! -s "/tmp/certs/private_key.priv" ]]; then
@@ -37,3 +38,6 @@ install -Dm644 /tmp/certs/private_key.priv /etc/pki/akmods/private/private_key.p
 
 # protect against incorrect permissions in tmp dirs which can break akmods builds
 chmod 1777 /tmp /var/tmp
+
+# create directories for later copying resulting artifacts
+mkdir -p /var/cache/rpms/{kmods,ublue-os}

--- a/build-ublue-os-nvidia-addons.sh
+++ b/build-ublue-os-nvidia-addons.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+
+sed -i "s@gpgcheck=0@gpgcheck=1@" /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/nvidia-container-runtime.repo
+
+rpmbuild -ba \
+    --define '_topdir /tmp/ublue-os-nvidia-addons/rpmbuild' \
+    --define '%_tmppath %{_topdir}/tmp' \
+    /tmp/ublue-os-nvidia-addons/ublue-os-nvidia-addons.spec

--- a/files/etc/nvidia-container-runtime/config-rootless.toml
+++ b/files/etc/nvidia-container-runtime/config-rootless.toml
@@ -1,0 +1,34 @@
+disable-require = false
+#swarm-resource = "DOCKER_RESOURCE_GPU"
+#accept-nvidia-visible-devices-envvar-when-unprivileged = true
+#accept-nvidia-visible-devices-as-volume-mounts = false
+
+[nvidia-container-cli]
+#root = "/run/nvidia/driver"
+#path = "/usr/bin/nvidia-container-cli"
+environment = []
+#debug = "/var/log/nvidia-container-toolkit.log"
+#ldcache = "/etc/ld.so.cache"
+load-kmods = true
+#no-cgroups = false
+no-cgroups = true
+#user = "root:video"
+ldconfig = "@/sbin/ldconfig"
+
+[nvidia-container-runtime]
+#debug = "/var/log/nvidia-container-runtime.log"
+debug = "~/.local/nvidia-container-runtime.log"
+log-level = "info"
+
+# Specify the runtimes to consider. This list is processed in order and the PATH
+# searched for matching executables unless the entry is an absolute path.
+runtimes = [
+    "docker-runc",
+    "runc",
+]
+
+mode = "auto"
+
+    [nvidia-container-runtime.modes.csv]
+
+    mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"

--- a/files/etc/sway/environment
+++ b/files/etc/sway/environment
@@ -1,0 +1,27 @@
+# This file is a part of Fedora configuration for Sway and will be sourced
+# from /usr/bin/start-sway script for all users of the system.
+# User-specific variables should be placed in $XDG_CONFIG_HOME/sway/environment
+#
+# vim: set ft=sh:
+
+## Pass extra arguments to the /usr/bin/sway executable
+
+#SWAY_EXTRA_ARGS="$SWAY_EXTRA_ARGS --unsupported-gpu"
+SWAY_EXTRA_ARGS="$SWAY_EXTRA_ARGS --unsupported-gpu -D noscanout"
+#SWAY_EXTRA_ARGS="$SWAY_EXTRA_ARGS --debug"
+
+## Set environment variables
+
+# Useful variables for wlroots:
+# https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/docs/env_vars.md
+#
+#WLR_NO_HARDWARE_CURSORS=1
+WLR_NO_HARDWARE_CURSORS=1
+# Setting renderer to Vulkan may fix flickering but needs the following extensions:
+# - VK_EXT_image_drm_format_modifier
+# - VK_EXT_physical_device_drm
+#
+# Source: https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/8e346922508aa3eaccd6e12f2917f6574f349843
+#WLR_RENDERER=vulkan
+
+# Application compatibility

--- a/ublue-os-nvidia-addons.spec
+++ b/ublue-os-nvidia-addons.spec
@@ -1,0 +1,78 @@
+Name:           ublue-os-nvidia-addons
+Version:        0.8
+Release:        1%{?dist}
+Summary:        Additional files for nvidia driver support
+
+License:        MIT
+URL:            https://github.com/ublue-os/nvidia
+
+BuildArch:      noarch
+Supplements:    mokutil policycoreutils
+
+Source0:        nvidia-container-runtime.repo
+Source1:        eyecantcu-supergfxctl.repo
+Source2:        config-rootless.toml
+Source3:        nvidia-container.pp
+Source4:        environment
+
+%description
+Adds various runtime files for nvidia support.
+
+%prep
+%setup -q -c -T
+
+
+%build
+# Have different name for *.der in case kmodgenca is needed for creating more keys
+install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
+install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
+install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
+install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
+install -Dm0644 %{SOURCE4} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/sway/environment
+
+sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/{eyecantcu-supergfxctl,nvidia-container-runtime}.repo
+
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo        %{buildroot}%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml %{buildroot}%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp             %{buildroot}%{_datadir}/selinux/packages/nvidia-container.pp
+
+%files
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/sway/environment
+%attr(0644,root,root) %{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
+%attr(0644,root,root) %{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
+%attr(0644,root,root) %{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
+%attr(0644,root,root) %{_datadir}/selinux/packages/nvidia-container.pp
+
+%changelog
+* Thu Aug 3 2023 RJ Trujillo <eyecantcu@pm.me> - 0.8
+- Add new copr for supergfxctl
+
+* Sat Jun 17 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.7
+- Remove MOK keys; now provided by ublue-os-akmods-addons
+
+* Sat Jun 17 2023 RJ Trujillo <eyecantcu@pm.me> - 0.6
+- Add supergfxctl-plasmoid COPR
+
+* Wed May 17 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.5
+- Add new ublue akmod public key for MOK enrollment
+
+* Sun Mar 26 2023 Joshua Stone <joshua.gage.stone@gmail.com> - 0.4
+- Add asus-linux COPR
+
+* Fri Feb 24 2023 Joshua Stone <joshua.gage.stone@gmail.com> - 0.3
+- Add sway environment file
+- Put ublue-os modifications into a separate data directory
+
+* Thu Feb 16 2023 Joshua Stone <joshua.gage.stone@gmail.com> - 0.2
+- Add nvidia-container-runtime repo
+- Add nvidia-container-runtime selinux policy file
+- Re-purpose into a general-purpose add-on package
+- Update URL to point to ublue-os project
+
+* Fri Feb 03 2023 Joshua Stone <joshua.gage.stone@gmail.com> - 0.1
+- Add key for enrolling kernel modules in alpha builds

--- a/ublue-os-nvidia-addons.spec
+++ b/ublue-os-nvidia-addons.spec
@@ -23,14 +23,11 @@ Adds various runtime files for nvidia support.
 
 
 %build
-# Have different name for *.der in case kmodgenca is needed for creating more keys
 install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
 install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/nvidia-container-runtime/config-rootless.toml
 install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
 install -Dm0644 %{SOURCE4} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/sway/environment
-
-sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/{eyecantcu-supergfxctl,nvidia-container-runtime}.repo
 
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/nvidia-container-runtime.repo
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo        %{buildroot}%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo


### PR DESCRIPTION
This adds nvidia kmod builds with a parameterized script which uses the nvidia major version to build the rpmfusion provided akmod for the respective nvidia version.

Also this builds the ublue-os-nvidia-addons which includes container runtime repo and sway environment setting for nvidia.

This mostly copies (with minor cleanup) from `ublue-os/nvidia` repo; once merged and building cleanly, the nvidia repo can be modified to build images using the kmods built here.

Only two somewhat significant changes (other than some scripting cleanup) stick out in my mind:
1. since I'm now building both 470 and 535 (and in future i guess this could be more) in a serial fashion, this does cause longer akmods build times, but... it's a daily thing, and the `nvidia` image builds are MUCH faster for when we need to just rebuild to pickup some change for synchronizing with `main` images
2. i no longer disable the nvidia-container-runtime and supergfxctl repos by default in the `ublue-os-nvidia-addons` RPM as this made things a bit difficult for consuming it in the `nvidia` image builds.  We can still disable those by default in the `nvidia` image builds if desired, and I will likely do so over there just to keep the same end state.