### PR TITLE
feat: split nvidia akmods into distinct images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        cfile_suffix: [common, nvidia]
         major_version: [37, 38]
+        nvidia_version: [0, 470, 535]
+        exclude:
+          - cfile_suffix: common
+            nvidia_version: 470
+          - cfile_suffix: common
+            nvidia_version: 535
+          - cfile_suffix: nvidia
+            nvidia_version: 0
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
@@ -33,7 +42,11 @@ jobs:
         run: |
           # Generate a timestamp for creating an image version history
           TIMESTAMP="$(date +%Y%m%d)"
-          VARIANT="${{ matrix.major_version }}"
+          if [[ "${{ matrix.cfile_suffix }}" == "nvidia" ]]; then
+              VARIANT="${{ matrix.major_version }}-${{ matrix.nvidia_version }}"
+          else
+              VARIANT="${{ matrix.major_version }}"
+          fi
 
           COMMIT_TAGS=()
           BUILD_TAGS=()
@@ -89,7 +102,7 @@ jobs:
         id: meta
         with:
           images: |
-            ${{ env.IMAGE_NAME }}
+            ${{ 'nvidia' == matrix.cfile_suffix && format('{0}-nvidia', env.IMAGE_NAME) || format('{0}', env.IMAGE_NAME) }}`
           labels: |
             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
             org.opencontainers.image.description=A caching layer for pre-built akmod RPMs
@@ -104,13 +117,14 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           containerfiles: |
-            ./Containerfile
-          image: ${{ env.IMAGE_NAME }}
+            ./Containerfile-${{ matrix.cfile_suffix }}
+          image: ${{ 'nvidia' == matrix.cfile_suffix && format('{0}-nvidia', env.IMAGE_NAME) || format('{0}', env.IMAGE_NAME) }}`
           tags: |
             ${{ steps.generate-tags.outputs.alias_tags }}
           build-args: |
             SOURCE_IMAGE=${{ env.SOURCE_IMAGE }}
             FEDORA_MAJOR_VERSION=${{ matrix.major_version }}
+            NVIDIA_MAJOR_VERSION=${{ matrix.nvidia_version }}
           labels: ${{ steps.meta.outputs.labels }}
           oci: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           containerfiles: |
-            ./Containerfile-${{ matrix.cfile_suffix }}
+            ./Containerfile.${{ matrix.cfile_suffix }}
           image: ${{ 'nvidia' == matrix.cfile_suffix && format('{0}-nvidia', env.IMAGE_NAME) || format('{0}', env.IMAGE_NAME) }}
           tags: |
             ${{ steps.generate-tags.outputs.alias_tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Push To GHCR
         uses: redhat-actions/push-to-registry@v2
         id: push
-        #if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         env:
           REGISTRY_USER: ${{ github.actor }}
           REGISTRY_PASSWORD: ${{ github.token }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
-        #if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
         id: meta
         with:
           images: |
-            ${{ 'nvidia' == matrix.cfile_suffix && format('{0}-nvidia', env.IMAGE_NAME) || format('{0}', env.IMAGE_NAME) }}`
+            ${{ 'nvidia' == matrix.cfile_suffix && format('{0}-nvidia', env.IMAGE_NAME) || format('{0}', env.IMAGE_NAME) }}
           labels: |
             org.opencontainers.image.title=${{ env.IMAGE_NAME }}
             org.opencontainers.image.description=A caching layer for pre-built akmod RPMs
@@ -118,7 +118,7 @@ jobs:
         with:
           containerfiles: |
             ./Containerfile-${{ matrix.cfile_suffix }}
-          image: ${{ 'nvidia' == matrix.cfile_suffix && format('{0}-nvidia', env.IMAGE_NAME) || format('{0}', env.IMAGE_NAME) }}`
+          image: ${{ 'nvidia' == matrix.cfile_suffix && format('{0}-nvidia', env.IMAGE_NAME) || format('{0}', env.IMAGE_NAME) }}
           tags: |
             ${{ steps.generate-tags.outputs.alias_tags }}
           build-args: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Push To GHCR
         uses: redhat-actions/push-to-registry@v2
         id: push
-        if: github.event_name != 'pull_request'
+        #if: github.event_name != 'pull_request'
         env:
           REGISTRY_USER: ${{ github.actor }}
           REGISTRY_PASSWORD: ${{ github.token }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
-        if: github.event_name != 'pull_request'
+        #if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/Containerfile.common
+++ b/Containerfile.common
@@ -1,0 +1,48 @@
+###
+### Containerfile.common - used to build ONLY NON-nvidia kmods
+###
+
+#Build from base, simpley because it's the smallest image
+ARG SOURCE_IMAGE="${SOURCE_IMAGE:-base}"
+ARG BASE_IMAGE="quay.io/fedora-ostree-desktops/${SOURCE_IMAGE}"
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-37}"
+
+FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS builder
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-37}"
+
+COPY build*.sh /tmp
+COPY certs /tmp/certs
+
+# files for akmods
+COPY ublue-os-akmods-addons.spec /tmp/ublue-os-akmods-addons/ublue-os-akmods-addons.spec
+ADD https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-${FEDORA_MAJOR_VERSION}/ublue-os-akmods-fedora-${FEDORA_MAJOR_VERSION}.repo \
+    /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo
+ADD https://negativo17.org/repos/fedora-steam.repo \
+    /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-steam.repo
+ADD https://negativo17.org/repos/fedora-multimedia.repo \
+    /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo    
+
+RUN /tmp/build-prep.sh
+
+RUN /tmp/build-ublue-os-akmods-addons.sh
+
+RUN /tmp/build-kmod-evdi.sh
+RUN /tmp/build-kmod-gasket.sh
+RUN /tmp/build-kmod-gcadapter_oc.sh
+RUN /tmp/build-kmod-openrgb.sh
+RUN /tmp/build-kmod-steamdeck.sh
+RUN /tmp/build-kmod-v4l2loopback.sh
+RUN /tmp/build-kmod-wl.sh
+RUN /tmp/build-kmod-xpadneo.sh
+
+RUN cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm \
+      /var/cache/rpms/ublue-os/
+RUN for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
+        cp "${RPM}" /var/cache/rpms/kmods/; \
+    done
+
+RUN find /var/cache/rpms
+
+FROM scratch
+
+COPY --from=builder /var/cache/rpms /rpms

--- a/Containerfile.nvidia
+++ b/Containerfile.nvidia
@@ -1,3 +1,7 @@
+###
+### Containerfile.nvidia - used to build ONLY NVIDIA kmods (one driver version per build)
+###
+
 #Build from base, simpley because it's the smallest image
 ARG SOURCE_IMAGE="${SOURCE_IMAGE:-base}"
 ARG BASE_IMAGE="quay.io/fedora-ostree-desktops/${SOURCE_IMAGE}"
@@ -5,18 +9,10 @@ ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-37}"
 
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS builder
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-37}"
+ARG NVIDIA_MAJOR_VERSION="${NVIDIA_MAJOR_VERSION:-470}"
 
 COPY build*.sh /tmp
 COPY certs /tmp/certs
-
-# files for akmods
-COPY ublue-os-akmods-addons.spec /tmp/ublue-os-akmods-addons/ublue-os-akmods-addons.spec
-ADD https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-${FEDORA_MAJOR_VERSION}/ublue-os-akmods-fedora-${FEDORA_MAJOR_VERSION}.repo \
-    /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo
-ADD https://negativo17.org/repos/fedora-steam.repo \
-    /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-steam.repo
-ADD https://negativo17.org/repos/fedora-multimedia.repo \
-    /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo    
 
 # files for nvidia
 COPY ublue-os-nvidia-addons.spec /tmp/ublue-os-nvidia-addons/ublue-os-nvidia-addons.spec
@@ -33,22 +29,11 @@ ADD files/etc/sway/environment /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/envi
 
 RUN /tmp/build-prep.sh
 
-RUN /tmp/build-ublue-os-akmods-addons.sh
 RUN /tmp/build-ublue-os-nvidia-addons.sh
 
-RUN /tmp/build-kmod-evdi.sh
-RUN /tmp/build-kmod-gasket.sh
-RUN /tmp/build-kmod-gcadapter_oc.sh
-RUN /tmp/build-kmod-openrgb.sh
-RUN /tmp/build-kmod-steamdeck.sh
-RUN /tmp/build-kmod-v4l2loopback.sh
-RUN /tmp/build-kmod-wl.sh
-RUN /tmp/build-kmod-xpadneo.sh
-RUN /tmp/build-kmod-nvidia.sh 470
-RUN /tmp/build-kmod-nvidia.sh 535
+RUN /tmp/build-kmod-nvidia.sh ${NVIDIA_MAJOR_VERSION}
 
-RUN cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm \
-       /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons*.rpm \
+RUN cp /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons*.rpm \
       /var/cache/rpms/ublue-os/
 RUN for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
         cp "${RPM}" /var/cache/rpms/kmods/; \

--- a/build-kmod-nvidia.sh
+++ b/build-kmod-nvidia.sh
@@ -18,7 +18,7 @@ else
     NVIDIA_PACKAGE_NAME="nvidia-${NVIDIA_MAJOR_VERSION}xx"
 fi
 
-dnf install -y \
+rpm-ostree install \
     akmod-${NVIDIA_PACKAGE_NAME}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE} \
     xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-{,cuda,devel,kmodsrc,power}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE}
 
@@ -44,7 +44,3 @@ NVIDIA_AKMOD_VERSION=${NVIDIA_AKMOD_VERSION}
 NVIDIA_LIB_VERSION=${NVIDIA_LIB_VERSION}
 EOF
 
-# cleanup for other nvidia builds
-dnf remove -y \
-    akmod-${NVIDIA_PACKAGE_NAME}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE} \
-    xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-{,cuda,devel,kmodsrc,power}*:${NVIDIA_MAJOR_VERSION}.*.fc${RELEASE}

--- a/build-prep.sh
+++ b/build-prep.sh
@@ -7,24 +7,25 @@ set -oeux pipefail
 ARCH="$(rpm -E '%_arch')"
 RELEASE="$(rpm -E '%fedora')"
 
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-{cisco-openh264,modular,updates-modular}.repo
 
-wget -P /tmp/rpms \
-    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
-    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
+sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-{cisco-openh264,modular,updates-modular}.repo
 
 # enable RPMs with alternatives to create them in this image build
 mkdir -p /var/lib/alternatives
 
+# allow simple `dnf install` style commands to work (in some spec scripts)
+ln -s /usr/bin/rpm-ostree /usr/bin/dnf
+
+# enable more repos
 rpm-ostree install \
-    /tmp/rpms/*.rpm \
+    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
+    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm \
     fedora-repos-archive
 
 
 ### PREPARE BUILD ENV
 rpm-ostree install \
     akmods \
-    dnf \
     mock
 
 if [[ ! -s "/tmp/certs/private_key.priv" ]]; then


### PR DESCRIPTION
In order to make both build time and minimize excess space used by consumers of akmods images, it is helpful to split the nvidia drivers each into their own distinct image.

The original `akmods` image returns to its very small (currently 1.7MB) size, and the new `akmods-nvidia` images will each be only the size of their respective kmod.