### PR TITLE
feat: Add xpad-noone driver

### DIFF
--- a/Containerfile.common
+++ b/Containerfile.common
@@ -34,6 +34,8 @@ RUN /tmp/build-kmod-steamdeck.sh
 RUN /tmp/build-kmod-v4l2loopback.sh
 RUN /tmp/build-kmod-wl.sh
 RUN /tmp/build-kmod-xpadneo.sh
+RUN /tmp/build-kmod-xpad-noone.sh
+RUN /tmp/build-kmod-xone.sh
 
 RUN cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm \
       /var/cache/rpms/ublue-os/

--- a/build-kmod-xpad-noone.sh
+++ b/build-kmod-xpad-noone.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+
+### BUILD xpad-noone (succeed or fail-fast with debug output)
+rpm-ostree install \
+    akmod-xpad-noone-*.fc${RELEASE}.${ARCH}
+akmods --force --kernels "${KERNEL}" --kmod xpad-noone
+modinfo /usr/lib/modules/${KERNEL}/extra/xpad-noone/xpad.ko.xz > /dev/null \
+|| (find /var/cache/akmods/xpad-noone/ -name \*.log -print -exec cat {} \; && exit 1)
+
+rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo


### PR DESCRIPTION
Built in [copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/) from our [xpad-noone](https://github.com/ublue-os/xpad-noone), which is just [upstream](https://github.com/paroj/xpad) with Xbox One controller IDs and vendor IDs [commented out](https://github.com/ublue-os/xpad-noone/commit/c6746b3e0a95a817550a686700eb3cdfe6b27c76#diff-3d985fe7837dec4db1df27733cece3b37633535ef91b1cbdf1c8b6eec4f692db).