### PR TITLE
feat: Add OpenRazer kmod

### DIFF
--- a/Containerfile.common
+++ b/Containerfile.common
@@ -29,6 +29,7 @@ RUN /tmp/build-ublue-os-akmods-addons.sh
 RUN /tmp/build-kmod-evdi.sh
 RUN /tmp/build-kmod-gasket.sh
 RUN /tmp/build-kmod-gcadapter_oc.sh
+RUN /tmp/build-kmod-openrazer.sh
 RUN /tmp/build-kmod-openrgb.sh
 RUN /tmp/build-kmod-steamdeck.sh
 RUN /tmp/build-kmod-v4l2loopback.sh

--- a/build-kmod-openrazer.sh
+++ b/build-kmod-openrazer.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+
+### BUILD openrazer (succeed or fail-fast with debug output)
+rpm-ostree install \
+    akmod-openrazer-*.fc${RELEASE}.${ARCH}
+akmods --force --kernels "${KERNEL}" --kmod openrazer
+modinfo /usr/lib/modules/${KERNEL}/extra/openrazer/razerkbd.ko.xz > /dev/null \
+|| (find /var/cache/akmods/openrazer/ -name \*.log -print -exec cat {} \; && exit 1)
+modinfo /usr/lib/modules/${KERNEL}/extra/openrazer/razermouse.ko.xz > /dev/null \
+|| (find /var/cache/akmods/openrazer/ -name \*.log -print -exec cat {} \; && exit 1)
+modinfo /usr/lib/modules/${KERNEL}/extra/openrazer/razerkraken.ko.xz > /dev/null \
+|| (find /var/cache/akmods/openrazer/ -name \*.log -print -exec cat {} \; && exit 1)
+modinfo /usr/lib/modules/${KERNEL}/extra/openrazer/razeraccessory.ko.xz > /dev/null \
+|| (find /var/cache/akmods/openrazer/ -name \*.log -print -exec cat {} \; && exit 1)
+
+rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo


### PR DESCRIPTION
Works by masquerading itself as the upstream dkms package with a very high version number so the remaining openrazer packages can be layered as normal.

Spec files are at: https://github.com/ublue-os/openrazer/

Closes #5