### PR TITLE
feat: Add ryzen_smu kmod

### DIFF
--- a/Containerfile.common
+++ b/Containerfile.common
@@ -31,6 +31,7 @@ RUN /tmp/build-kmod-gasket.sh
 RUN /tmp/build-kmod-gcadapter_oc.sh
 RUN /tmp/build-kmod-openrazer.sh
 RUN /tmp/build-kmod-openrgb.sh
+RUN /tmp/build-kmod-ryzen-smu.sh
 RUN /tmp/build-kmod-steamdeck.sh
 RUN /tmp/build-kmod-v4l2loopback.sh
 RUN /tmp/build-kmod-wl.sh

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Feel free to PR more kmod build scripts into this repo!
 - [gasket/apex](https://github.com/google/gasket-driver) - kernel module for Coral Gasket Driver, allowing usage of the Coral EdgeTPU on Linux systems (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [gcadapter_oc](https://github.com/hannesmann/gcadapter-oc-kmod) - kernel module for overclocking the Nintendo Wii U/Mayflash GameCube adapter (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [nvidia](https://rpmfusion.org/Howto/NVIDIA) - nvidia GPU drivers built from rpmfusion
+- [openrazer](https://openrazer.github.io/) - kernel module adding additional features to Razer hardware (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [openrgb](https://gitlab.com/CalcProgrammer1/OpenRGB/-/raw/master/OpenRGB.patch) - kernel module with i2c-nct6775 and patched i2c-piix4 for use with OpenRGB (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
+- [ryzen_smu](https://gitlab.com/leogx9r/ryzen_smu) - A Linux kernel driver that exposes access to the SMU (System Management Unit) for certain AMD Ryzen Processors (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [steamdeck](https://lkml.org/lkml/2022/2/5/391) - platform driver for Valve's Steam Deck handheld PC (akmod from [ublue-os/akmods copr](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/))
 - [v4l2loopback](https://github.com/umlaeute/v4l2loopback) - allows creating "virtual video devices"
 - [wl (broadcom)](https://github.com/rpmfusion/broadcom-wl/) - support for some legacy broadcom wifi devices

--- a/build-kmod-ryzen-smu.sh
+++ b/build-kmod-ryzen-smu.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+
+### BUILD ryzen-smu (succeed or fail-fast with debug output)
+rpm-ostree install \
+    akmod-ryzen-smu-*.fc${RELEASE}.${ARCH}
+akmods --force --kernels "${KERNEL}" --kmod ryzen-smu
+modinfo /usr/lib/modules/${KERNEL}/extra/ryzen-smu/ryzen_smu.ko.xz > /dev/null \
+|| (find /var/cache/akmods/ryzen-smu/ -name \*.log -print -exec cat {} \; && exit 1)
+
+rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo


### PR DESCRIPTION
A Linux kernel driver that exposes access to the SMU (System Management Unit) for certain AMD Ryzen Processors.