### PR TITLE
chore(ci): restore F39 builds for kmods

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         cfile_suffix: [common, nvidia]
-        major_version: [37, 38]
+        major_version: [37, 38, 39]
         nvidia_version: [0, 470, 535]
         exclude:
           - cfile_suffix: common


### PR DESCRIPTION
This should be merged after https://github.com/ublue-os/main/issues/356 is merged.