### PR TITLE
feat: auto-generate CDI yaml for nvidia

### DIFF
--- a/Containerfile.nvidia
+++ b/Containerfile.nvidia
@@ -24,6 +24,8 @@ ADD https://copr.fedorainfracloud.org/coprs/eyecantcu/supergfxctl/repo/fedora-${
 ADD https://raw.githubusercontent.com/NVIDIA/dgx-selinux/master/bin/RHEL9/nvidia-container.pp \
     /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/nvidia-container.pp
 ADD files/etc/sway/environment /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/environment
+ADD files/usr/lib/systemd/system/ublue-nvctk-cdi.service /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/ublue-nvctk-cdi.service
+ADD files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/70-ublue-nvctk-cdi.preset
 
 
 RUN /tmp/build-prep.sh

--- a/files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset
+++ b/files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset
@@ -1,0 +1,1 @@
+enable ublue-nvctk-cdi.service

--- a/files/usr/lib/systemd/system/ublue-nvctk-cdi.service
+++ b/files/usr/lib/systemd/system/ublue-nvctk-cdi.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=ublue nvidia container toolkit CDI auto-generation
+ConditionFileIsExecutable=/usr/bin/nvidia-ctk
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+
+[Install]
+WantedBy=multi-user.target

--- a/ublue-os-nvidia-addons.spec
+++ b/ublue-os-nvidia-addons.spec
@@ -1,5 +1,5 @@
 Name:           ublue-os-nvidia-addons
-Version:        0.9
+Version:        0.10
 Release:        1%{?dist}
 Summary:        Additional files for nvidia driver support
 
@@ -13,6 +13,8 @@ Source0:        nvidia-container-toolkit.repo
 Source1:        eyecantcu-supergfxctl.repo
 Source2:        nvidia-container.pp
 Source3:        environment
+Source4:        ublue-nvctk-cdi.service
+Source5:        70-ublue-nvctk-cdi.preset
 
 %description
 Adds various runtime files for nvidia support.
@@ -26,21 +28,30 @@ install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.r
 install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
 install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/sway/environment
+install -Dm0644 %{SOURCE4} %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service
+install -Dm0644 %{SOURCE5} %{buildroot}%{_presetdir}/70-ublue-nvctk-cdi.preset
 
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo        %{buildroot}%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp             %{buildroot}%{_datadir}/selinux/packages/nvidia-container.pp
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service                          %{buildroot}%{_unitdir}/ublue-nvctk-cdi.service
 
 %files
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/sway/environment
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service
 %attr(0644,root,root) %{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
 %attr(0644,root,root) %{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 %attr(0644,root,root) %{_datadir}/selinux/packages/nvidia-container.pp
+%attr(0644,root,root) %{_unitdir}/ublue-nvctk-cdi.service
+%attr(0644,root,root) %{_presetdir}/70-ublue-nvctk-cdi.preset
 
 %changelog
+* Fri Oct 6 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.10
+- add ublue-nvctk-cdi service to auto-generate NVIDIA CDI GPU definitions
+
 * Thu Oct 5 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.9
 - use newer nvidia-container-toolkit repo
 - repo provides newer toolkit, no longer requires config.toml


### PR DESCRIPTION
This is useful to have nvidia devices ready to go for container use on boot.