### PR TITLE
feat: Enable Surface akmods for Fedora 39

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,6 @@ jobs:
           - kernel_flavor: surface
             major_version: 37
           - kernel_flavor: surface
-            major_version: 39
-          - kernel_flavor: surface
             nvidia_version: 470
     steps:
       # Checkout push-to-registry action GitHub repository


### PR DESCRIPTION
The Surface kernel for Fedora 39 is ready!