### PR TITLE
feat: use official upstream images for kmod builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   merge_group:
   schedule:
-    - cron: '0 6 * * *'  # 6am everyday (1h after 'config')
+    - cron: '0 14 * * *'  # 2pm UTC everyday (timed against official fedora container pushes, and after 'config')
   workflow_dispatch:
 env:
     IMAGE_NAME: akmods
@@ -12,7 +12,7 @@ env:
 
 jobs:
   push-ghcr:
-    name: Build and push akmods image
+    name: akmods image
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
 env:
     IMAGE_NAME: akmods
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
-    SOURCE_IMAGE: base
 
 jobs:
   push-ghcr:
@@ -42,6 +41,17 @@ jobs:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
         uses: actions/checkout@v4
+
+      - name: Matrix Variables
+        shell: bash
+        run: |
+          if [[ "${{ matrix.major_version }}" -ge "39" ]]; then
+              echo "SOURCE_IMAGE=fedora-silverblue" >> $GITHUB_ENV
+              echo "SOURCE_ORG=fedora" >> $GITHUB_ENV
+          else
+              echo "SOURCE_IMAGE=base" >> $GITHUB_ENV
+              echo "SOURCE_ORG=fedora-ostree-desktops" >> $GITHUB_ENV
+          fi
 
       - name: Generate tags
         id: generate-tags
@@ -97,7 +107,7 @@ jobs:
       - name: Get current versions
         id: labels
         run: |
-          skopeo inspect docker://quay.io/fedora-ostree-desktops/${{ env.SOURCE_IMAGE }}:${{ matrix.major_version }} > inspect.json
+          skopeo inspect docker://quay.io/${{ env.SOURCE_ORG }}/${{ env.SOURCE_IMAGE }}:${{ matrix.major_version }} > inspect.json
           version=$(jq -r '.Labels["org.opencontainers.image.version"]' inspect.json)
           linux=$(jq -r '.Labels["ostree.linux"]' inspect.json)
           echo "VERSION=$version" >> $GITHUB_OUTPUT
@@ -130,6 +140,7 @@ jobs:
             ${{ steps.generate-tags.outputs.alias_tags }}
           build-args: |
             SOURCE_IMAGE=${{ env.SOURCE_IMAGE }}
+            SOURCE_ORG=${{ env.SOURCE_ORG }}
             KERNEL_FLAVOR=${{ matrix.kernel_flavor }}
             FEDORA_MAJOR_VERSION=${{ matrix.major_version }}
             NVIDIA_MAJOR_VERSION=${{ matrix.nvidia_version }}

--- a/Containerfile.common
+++ b/Containerfile.common
@@ -4,7 +4,7 @@
 
 #Build from base, simpley because it's the smallest image
 ARG SOURCE_IMAGE="${SOURCE_IMAGE:-base}"
-ARG SOURCE_ORG="${SOURCE_ORG:-fedora-ostree-desktops}
+ARG SOURCE_ORG="${SOURCE_ORG:-fedora-ostree-desktops}"
 ARG BASE_IMAGE="quay.io/${SOURCE_ORG}/${SOURCE_IMAGE}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
 

--- a/Containerfile.common
+++ b/Containerfile.common
@@ -4,7 +4,8 @@
 
 #Build from base, simpley because it's the smallest image
 ARG SOURCE_IMAGE="${SOURCE_IMAGE:-base}"
-ARG BASE_IMAGE="quay.io/fedora-ostree-desktops/${SOURCE_IMAGE}"
+ARG SOURCE_ORG="${SOURCE_ORG:-fedora-ostree-desktops}
+ARG BASE_IMAGE="quay.io/${SOURCE_ORG}/${SOURCE_IMAGE}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
 
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS builder

--- a/Containerfile.nvidia
+++ b/Containerfile.nvidia
@@ -4,7 +4,7 @@
 
 #Build from base, simpley because it's the smallest image
 ARG SOURCE_IMAGE="${SOURCE_IMAGE:-base}"
-ARG SOURCE_ORG="${SOURCE_ORG:-fedora-ostree-desktops}
+ARG SOURCE_ORG="${SOURCE_ORG:-fedora-ostree-desktops}"
 ARG BASE_IMAGE="quay.io/${SOURCE_ORG}/${SOURCE_IMAGE}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
 

--- a/Containerfile.nvidia
+++ b/Containerfile.nvidia
@@ -4,7 +4,8 @@
 
 #Build from base, simpley because it's the smallest image
 ARG SOURCE_IMAGE="${SOURCE_IMAGE:-base}"
-ARG BASE_IMAGE="quay.io/fedora-ostree-desktops/${SOURCE_IMAGE}"
+ARG SOURCE_ORG="${SOURCE_ORG:-fedora-ostree-desktops}
+ARG BASE_IMAGE="quay.io/${SOURCE_ORG}/${SOURCE_IMAGE}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
 
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS builder


### PR DESCRIPTION
This change does two things:
1) uses official upstream `silverblue` image, rather than the QA build of `base`, as our builder
2) changes cron to 1400 UTC to more closely match the time of official image builds

This change matches with the changes in https://github.com/ublue-os/main/pull/407