### PR TITLE
chore: restore default rpmfusion mirror behavior

### DIFF
--- a/build-prep.sh
+++ b/build-prep.sh
@@ -28,14 +28,6 @@ rpm-ostree install \
     https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm \
     fedora-repos-archive
 
-# force use of single rpmfusion mirror
-sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
-sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
-# after F39 launches, bump to 40
-if [[ "${FEDORA_MAJOR_VERSION}" -ge 39 ]]; then
-    sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo
-fi
-
 
 ### PREPARE CUSTOM KERNEL SUPPORT
 if [[ "asus" == "${KERNEL_FLAVOR}" ]]; then


### PR DESCRIPTION
Ah while back, I made a change to akmods/main/nvidia repos to force them to use the same rpmfusion mirror during builds (this gets reset to defaults for resulting images).

This is problematic for F39, since, at the least, it will require a path change due to F39 promoting from "development" to "release".

Should this be removed completely (as I've done in this PR so far) or should we just change the conditional from F39 to F40?