### PR TITLE
fix(xbox): Replace negativo17 fedora-steam repo with fedora-multimedia

### DIFF
--- a/Containerfile.common
+++ b/Containerfile.common
@@ -19,8 +19,6 @@ COPY certs /tmp/certs
 COPY ublue-os-akmods-addons.spec /tmp/ublue-os-akmods-addons/ublue-os-akmods-addons.spec
 ADD https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-${FEDORA_MAJOR_VERSION}/ublue-os-akmods-fedora-${FEDORA_MAJOR_VERSION}.repo \
     /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo
-ADD https://negativo17.org/repos/fedora-steam.repo \
-    /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-steam.repo
 ADD https://negativo17.org/repos/fedora-multimedia.repo \
     /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo    
 

--- a/build-kmod-xone.sh
+++ b/build-kmod-xone.sh
@@ -3,7 +3,7 @@
 set -oeux pipefail
 
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-steam.repo /etc/yum.repos.d/
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo /etc/yum.repos.d/
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
@@ -17,4 +17,4 @@ akmods --force --kernels "${KERNEL}" --kmod xone
 modinfo /usr/lib/modules/${KERNEL}/extra/xone/xone-{dongle,gip-chatpad,gip-gamepad,gip-guitar,gip-headset,gip,wired}.ko.xz > /dev/null \
 || (find /var/cache/akmods/xone/ -name \*.log -print -exec cat {} \; && exit 1)
 
-rm -f /etc/yum.repos.d/negativo17-fedora-steam.repo
+rm -f /etc/yum.repos.d/negativo17-fedora-multimedia.repo

--- a/build-kmod-xpadneo.sh
+++ b/build-kmod-xpadneo.sh
@@ -3,7 +3,7 @@
 set -oeux pipefail
 
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-steam.repo /etc/yum.repos.d/
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo /etc/yum.repos.d/
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
@@ -17,4 +17,4 @@ akmods --force --kernels "${KERNEL}" --kmod xpadneo
 modinfo /usr/lib/modules/${KERNEL}/extra/xpadneo/hid-xpadneo.ko.xz > /dev/null \
 || (find /var/cache/akmods/xpadneo/ -name \*.log -print -exec cat {} \; && exit 1)
 
-rm -f /etc/yum.repos.d/negativo17-fedora-steam.repo
+rm -f /etc/yum.repos.d/negativo17-fedora-multimedia.repo

--- a/ublue-os-akmods-addons.spec
+++ b/ublue-os-akmods-addons.spec
@@ -42,7 +42,7 @@ install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nega
 
 %changelog
 * Mon Nov 20 2023 RJ Trujillo <eyecantcu@pm.me> - 0.4
-- Remove negativo17 fedora-steam repo
+- Migrate xpadneo/xone modules from negativo17 fedora-steam to negativo17 fedora-multimedia
 
 * Mon Jul 17 2023 Kyle Gospodnetich <me@kylegospodneti.ch> - 0.3
 - Add ublue-os/akmods copr repo for modules not available upstream/elsewhere

--- a/ublue-os-akmods-addons.spec
+++ b/ublue-os-akmods-addons.spec
@@ -11,6 +11,7 @@ Supplements:    mokutil policycoreutils
 
 Source0:        public_key.der
 Source1:        _copr_ublue-os-akmods.repo
+Source2:        negativo17-fedora-multimedia.repo
 
 %description
 Adds the signing key for importing with mokutil to enable secure boot for kernel modules and repo files required to install akmod dependencies.
@@ -23,15 +24,21 @@ Adds the signing key for importing with mokutil to enable secure boot for kernel
 # Have different name for *.der in case kmodgenca is needed for creating more keys
 install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
 install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo
+install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-multimedia.repo
+
+sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-multimedia.repo
 
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der            %{buildroot}%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo    %{buildroot}%{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-multimedia.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/negativo17-fedora-multimedia.repo
 
 %files
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-multimedia.repo
 %attr(0644,root,root) %{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
 %attr(0644,root,root) %{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo
+%attr(0644,root,root) %{_sysconfdir}/yum.repos.d/negativo17-fedora-multimedia.repo
 
 %changelog
 * Mon Nov 20 2023 RJ Trujillo <eyecantcu@pm.me> - 0.4

--- a/ublue-os-akmods-addons.spec
+++ b/ublue-os-akmods-addons.spec
@@ -11,7 +11,6 @@ Supplements:    mokutil policycoreutils
 
 Source0:        public_key.der
 Source1:        _copr_ublue-os-akmods.repo
-Source2:        negativo17-fedora-steam.repo
 
 %description
 Adds the signing key for importing with mokutil to enable secure boot for kernel modules and repo files required to install akmod dependencies.
@@ -24,23 +23,20 @@ Adds the signing key for importing with mokutil to enable secure boot for kernel
 # Have different name for *.der in case kmodgenca is needed for creating more keys
 install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
 install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo
-install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-steam.repo
-
-sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-steam.repo
 
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der            %{buildroot}%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo    %{buildroot}%{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo
-install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-steam.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/negativo17-fedora-steam.repo
 
 %files
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo
-%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-steam.repo
 %attr(0644,root,root) %{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
 %attr(0644,root,root) %{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo
-%attr(0644,root,root) %{_sysconfdir}/yum.repos.d/negativo17-fedora-steam.repo
 
 %changelog
+* Mon Nov 20 2023 RJ Trujillo <eyecantcu@pm.me> - 0.4
+- Remove negativo17 fedora-steam repo
+
 * Mon Jul 17 2023 Kyle Gospodnetich <me@kylegospodneti.ch> - 0.3
 - Add ublue-os/akmods copr repo for modules not available upstream/elsewhere
 


### PR DESCRIPTION
fedora-steam appears to have been dropped with its components relocated to fedora-multimedia