### PR TITLE
chore: fix missing ublue-os-akmods-addons version bump

### DIFF
--- a/ublue-os-akmods-addons.spec
+++ b/ublue-os-akmods-addons.spec
@@ -1,5 +1,5 @@
 Name:           ublue-os-akmods-addons
-Version:        0.3
+Version:        0.4
 Release:        1%{?dist}
 Summary:        Signing key and repos for ublue os akmods
 


### PR DESCRIPTION
I missed that the version bump was missed in #96 

This corrects that.