### PR TITLE
feat: Fedora 37 is EOL 2023-12-05

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         kernel_flavor: [main, asus, fsync, surface]
         cfile_suffix: [common, nvidia]
-        major_version: [37, 38, 39]
+        major_version: [38, 39]
         nvidia_version: [0, 470, 545]
         exclude:
           - cfile_suffix: common
@@ -31,14 +31,8 @@ jobs:
             nvidia_version: 545
           - cfile_suffix: nvidia
             nvidia_version: 0
-          - kernel_flavor: asus
-            major_version: 37
-          - kernel_flavor: fsync
-            major_version: 37
           - kernel_flavor: fsync
             major_version: 38
-          - kernel_flavor: surface
-            major_version: 37
           - kernel_flavor: surface
             nvidia_version: 470
     steps:

--- a/README.md
+++ b/README.md
@@ -40,9 +40,8 @@ The majority of the drivers are tagged with `KERNEL_TYPE-FEDORA_RELEASE`. NVIDIA
 
 | KERNEL_TYPE | FEDORA_RELEASE | TAG |
 | - | - | - |
-| Fedora stock kernel | 37 | `main-37`, `main-37-470` `main-37-545` |
-| | 38 | `main-38`, `main-38-470` `main-38-545` |
-| | 39 | `main-38`, `main-38-470` `main-38-545` |
+| Fedora stock kernel | 38 | `main-38`, `main-38-470` `main-38-545` |
+| | 39 | `main-39`, `main-39-470` `main-39-545` |
 | [patched for ASUS devices](https://copr.fedorainfracloud.org/coprs/lukenukem/asus-kernel) | 38 | `asus-38`, `asus-38-470` `asus-38-545` |
 | | 39 | `asus-39`, `asus-39-470` `asus-39-545` |
 | [patched Microsoft Surface devices](https://github.com/linux-surface/linux-surface/) | 38 | `surface-38`, `surface-38-545` |
@@ -80,7 +79,7 @@ If you have a kmod you want to contribute send a pull request by adding a script
 
 # Verification
 
-These images are signed with sisgstore's [cosign](https://docs.sigstore.dev/cosign/overview/). You can verify the signature by downloading the `cosign.pub` key from this repo and running the following command, replacing `RELEASE` with either `37` or `38`:
+These images are signed with sisgstore's [cosign](https://docs.sigstore.dev/cosign/overview/). You can verify the signature by downloading the `cosign.pub` key from this repo and running the following command, replacing `RELEASE` with either `38` or `39`:
 
     cosign verify --key cosign.pub ghcr.io/ublue-os/akmods:RELEASE
 

--- a/build-prep.sh
+++ b/build-prep.sh
@@ -17,11 +17,6 @@ fi
 # enable RPMs with alternatives to create them in this image build
 mkdir -p /var/lib/alternatives
 
-# allow simple `dnf install` style commands to work (in some spec scripts)
-if [[ "${RELEASE}" -eq "37" ]]; then
-    ln -s /usr/bin/rpm-ostree /usr/bin/dnf
-fi
-
 # enable more repos
 rpm-ostree install \
     https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \


### PR DESCRIPTION
Planned removal of Fedora 37 due to EOL.