### PR TITLE
chore(ci): pin to single berkley mirror

### DIFF
--- a/build-prep.sh
+++ b/build-prep.sh
@@ -19,9 +19,17 @@ mkdir -p /var/lib/alternatives
 
 # enable more repos
 rpm-ostree install \
-    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
-    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm \
+    http://mirrors.ocf.berkeley.edu/rpmfusion/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
+    http://mirrors.ocf.berkeley.edu/rpmfusion/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm \
     fedora-repos-archive
+
+# force use of single rpmfusion mirror
+sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
+sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
+# after F40 launches, bump to 41
+if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
+    sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo
+fi
 
 
 ### PREPARE CUSTOM KERNEL SUPPORT


### PR DESCRIPTION
This consistently pins the build to the same mirror so jobs running on different runners should have the same set of packages to consistently succeed/fail.