### PR TITLE
feat: enable preview of Fedora 40 kmod builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,15 @@ jobs:
             major_version: 38
           - kernel_flavor: surface
             nvidia_version: 470
+          - major_version: 40
+            nvidia_version: 470 # This driver version is not packaged for Fedora 40.
+          - major_version: 40
+            cfile_suffix: common # negativo17's multimedia repo is not branched yet.
+          - major_version: 40
+            kernel_flavor: surface # linux-surface is not branched for F40 yet.
+          - major_version: 40
+            kernel_flavor: fsync # kernel-fsync packages are not being built for F40 yet.
+          
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         kernel_flavor: [main, asus, 6.7.9-204.fsync, surface]
         cfile_suffix: [common, nvidia]
-        major_version: [38, 39]
+        major_version: [38, 39, 40]
         nvidia_version: [0, 470, 550]
         exclude:
           - cfile_suffix: common
@@ -45,7 +45,8 @@ jobs:
       - name: Matrix Variables
         shell: bash
         run: |
-          if [[ "${{ matrix.major_version }}" -ge "40" ]]; then
+          if [[ "${{ matrix.major_version }}" -ge "41" ]]; then
+              # when we are confident of official fedora images we can switch to them
               echo "SOURCE_IMAGE=fedora-silverblue" >> $GITHUB_ENV
               echo "SOURCE_ORG=fedora" >> $GITHUB_ENV
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,13 +38,9 @@ jobs:
           - kernel_flavor: surface
             nvidia_version: 470
           - major_version: 40
-            nvidia_version: 470 # This driver version is not packaged for Fedora 40.
+            nvidia_version: 470 # rpmfusion packages nvidia 470 for F40 but won't compile yet.
           - major_version: 40
-            cfile_suffix: common # negativo17's multimedia repo is not branched yet.
-          - major_version: 40
-            kernel_flavor: surface # linux-surface is not branched for F40 yet.
-          - major_version: 40
-            kernel_flavor: fsync # kernel-fsync packages are not being built for F40 yet.
+            kernel_flavor: 6.7.9-204.fsync # kernel-fsync packages are not being built for F40 yet.
           
     steps:
       # Checkout push-to-registry action GitHub repository

--- a/Containerfile.common
+++ b/Containerfile.common
@@ -21,14 +21,13 @@ COPY ublue-os-akmods-addons.spec /tmp/ublue-os-akmods-addons/ublue-os-akmods-add
 ADD https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-${FEDORA_MAJOR_VERSION}/ublue-os-akmods-fedora-${FEDORA_MAJOR_VERSION}.repo \
     /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo
 ADD https://negativo17.org/repos/fedora-multimedia.repo \
-    /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo    
+    /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo
 
 RUN /tmp/build-prep.sh
 
 RUN /tmp/build-ublue-os-akmods-addons.sh
 
 # Set kernel name
-# Exclude negativo17 kmods from Fedora 39
 RUN if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
         export KERNEL_NAME="kernel" \
     ; else \

--- a/build-kmod-ayaneo-platform.sh
+++ b/build-kmod-ayaneo-platform.sh
@@ -2,11 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 rpm-ostree install \
     akmod-ayaneo-platform-*.fc${RELEASE}.${ARCH}

--- a/build-kmod-ayn-platform.sh
+++ b/build-kmod-ayn-platform.sh
@@ -2,11 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 rpm-ostree install \
     akmod-ayn-platform-*.fc${RELEASE}.${ARCH}

--- a/build-kmod-bmi160.sh
+++ b/build-kmod-bmi160.sh
@@ -2,11 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 rpm-ostree install \
     akmod-bmi160-*.fc${RELEASE}.${ARCH}

--- a/build-kmod-bmi260.sh
+++ b/build-kmod-bmi260.sh
@@ -2,11 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 rpm-ostree install \
     akmod-bmi260-*.fc${RELEASE}.${ARCH}

--- a/build-kmod-bmi323.sh
+++ b/build-kmod-bmi323.sh
@@ -2,11 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 rpm-ostree install \
     akmod-bmi323-*.fc${RELEASE}.${ARCH}

--- a/build-kmod-evdi.sh
+++ b/build-kmod-evdi.sh
@@ -3,12 +3,16 @@
 set -oeux pipefail
 
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
+if [ "40" == "${RELEASE}" ]; then
+  echo "SKIPPED BUILD of evdi: negativo17 not supporting F40 yet"
+  exit 0
+fi
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo /etc/yum.repos.d/
 
 ### BUILD evdi (succeed or fail-fast with debug output)
 export CFLAGS="-fno-pie -no-pie"

--- a/build-kmod-gasket.sh
+++ b/build-kmod-gasket.sh
@@ -2,11 +2,16 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
+
+if [ "40" == "${RELEASE}" ]; then
+  echo "SKIPPED BUILD of gasket: compile failure on F40 as of 2024-03-17"
+  exit 0
+fi
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 rpm-ostree install \
     akmod-gasket-*.fc${RELEASE}.${ARCH}

--- a/build-kmod-gcadapter_oc.sh
+++ b/build-kmod-gcadapter_oc.sh
@@ -2,11 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 rpm-ostree install \
     akmod-gcadapter_oc-*.fc${RELEASE}.${ARCH}

--- a/build-kmod-nct6687d.sh
+++ b/build-kmod-nct6687d.sh
@@ -2,12 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 ### BUILD nct6687d (succeed or fail-fast with debug output)
 rpm-ostree install \

--- a/build-kmod-openrazer.sh
+++ b/build-kmod-openrazer.sh
@@ -2,12 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 ### BUILD openrazer (succeed or fail-fast with debug output)
 rpm-ostree install \

--- a/build-kmod-openrgb.sh
+++ b/build-kmod-openrgb.sh
@@ -2,11 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 rpm-ostree install \
     akmod-openrgb-*.fc${RELEASE}.${ARCH}

--- a/build-kmod-rtl8814au.sh
+++ b/build-kmod-rtl8814au.sh
@@ -2,12 +2,18 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
+if [ "40" == "${RELEASE}" ]; then
+  echo "SKIPPED BUILD of rtl8814au: compile failure on F40 as of 2024-03-17"
+  exit 0
+fi
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
+
+rpm-ostree install \
 rpm-ostree install \
     akmod-rtl8814au-*.fc${RELEASE}.${ARCH}
 akmods --force --kernels "${KERNEL}" --kmod rtl8814au

--- a/build-kmod-rtl8814au.sh
+++ b/build-kmod-rtl8814au.sh
@@ -14,7 +14,6 @@ fi
 cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 rpm-ostree install \
-rpm-ostree install \
     akmod-rtl8814au-*.fc${RELEASE}.${ARCH}
 akmods --force --kernels "${KERNEL}" --kmod rtl8814au
 modinfo /usr/lib/modules/${KERNEL}/extra/rtl8814au/rtl8814au.ko.xz > /dev/null \

--- a/build-kmod-rtl88xxau.sh
+++ b/build-kmod-rtl88xxau.sh
@@ -2,11 +2,16 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
+
+if [ "40" == "${RELEASE}" ]; then
+  echo "SKIPPED BUILD of rtl88xxau: compile failure on F40 as of 2024-03-17"
+  exit 0
+fi
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 rpm-ostree install \
     akmod-rtl88xxau-*.fc${RELEASE}.${ARCH}

--- a/build-kmod-ryzen-smu.sh
+++ b/build-kmod-ryzen-smu.sh
@@ -2,12 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 ### BUILD ryzen-smu (succeed or fail-fast with debug output)
 rpm-ostree install \

--- a/build-kmod-steamdeck.sh
+++ b/build-kmod-steamdeck.sh
@@ -2,11 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 rpm-ostree install \
     akmod-steamdeck-*.fc${RELEASE}.${ARCH}

--- a/build-kmod-v4l2loopback.sh
+++ b/build-kmod-v4l2loopback.sh
@@ -8,6 +8,11 @@ KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')
 RELEASE="$(rpm -E '%fedora')"
 
 
+if [ "40" == "${RELEASE}" ]; then
+  echo "SKIPPED BUILD of v4l2loopback: compile failure on F40 as of 2024-03-17"
+  exit 0
+fi
+
 ### BUILD v4l2loopbak (succeed or fail-fast with debug output)
 rpm-ostree install \
     akmod-v4l2loopback-*.fc${RELEASE}.${ARCH}

--- a/build-kmod-winesync.sh
+++ b/build-kmod-winesync.sh
@@ -2,12 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 ### BUILD winesync (succeed or fail-fast with debug output)
 rpm-ostree install \

--- a/build-kmod-xone.sh
+++ b/build-kmod-xone.sh
@@ -2,12 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 ### BUILD xone (succeed or fail-fast with debug output)
 rpm-ostree install \

--- a/build-kmod-xpadneo.sh
+++ b/build-kmod-xpadneo.sh
@@ -3,12 +3,16 @@
 set -oeux pipefail
 
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
+if [ "40" == "${RELEASE}" ]; then
+  echo "SKIPPED BUILD of xpadneo: negativo17 not supporting F40 yet"
+  exit 0
+fi
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo /etc/yum.repos.d/
 
 ### BUILD xpadneo (succeed or fail-fast with debug output)
 rpm-ostree install \

--- a/build-kmod-zenergy.sh
+++ b/build-kmod-zenergy.sh
@@ -2,11 +2,11 @@
 
 set -oeux pipefail
 
-cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
-
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
 
 rpm-ostree install \
     akmod-zenergy-*.fc${RELEASE}.${ARCH}

--- a/build-prep.sh
+++ b/build-prep.sh
@@ -32,10 +32,12 @@ if [ -n "${RPMFUSION_MIRROR}" ]; then
     echo "Using single rpmfusion mirror: ${RPMFUSION_MIRROR}"
     sed -i.bak "s%^metalink=%#metalink=%" /etc/yum.repos.d/rpmfusion-*.repo
     sed -i "s%^#baseurl=http://download1.rpmfusion.org%baseurl=${RPMFUSION_MIRROR}%" /etc/yum.repos.d/rpmfusion-*.repo
-    # after F40 launches, bump to 41
-    if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
-        sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
-    fi
+fi
+
+# after F40 launches, bump to 41
+if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
+    # pre-release rpmfusion is in a different location
+    sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
 fi
 
 ### PREPARE CUSTOM KERNEL SUPPORT

--- a/build-prep.sh
+++ b/build-prep.sh
@@ -27,17 +27,19 @@ rpm-ostree install \
     ${RPMFUSION_MIRROR_RPMS}/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm \
     fedora-repos-archive
 
+# after F40 launches, bump to 41
+if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
+    # pre-release rpmfusion is in a different location
+    sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
+    # pre-release rpmfusion needs to enable testing
+    sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/rpmfusion-*-updates-testing.repo
+fi
+
 if [ -n "${RPMFUSION_MIRROR}" ]; then
     # force use of single rpmfusion mirror
     echo "Using single rpmfusion mirror: ${RPMFUSION_MIRROR}"
     sed -i.bak "s%^metalink=%#metalink=%" /etc/yum.repos.d/rpmfusion-*.repo
     sed -i "s%^#baseurl=http://download1.rpmfusion.org%baseurl=${RPMFUSION_MIRROR}%" /etc/yum.repos.d/rpmfusion-*.repo
-fi
-
-# after F40 launches, bump to 41
-if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
-    # pre-release rpmfusion is in a different location
-    sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
 fi
 
 ### PREPARE CUSTOM KERNEL SUPPORT


### PR DESCRIPTION
This enables Fedora 40 builds, but filters out known problems.

Specifically, when the build version is Fedora 40, this disables several kmods which are either not yet available for Fedora 40 in upstream repos or do not currently compile against Fedora 40.

The disabled kmod list:
- evdi: negativo17 does not yet provide F40
- gasket: compile failure
- nvidia-470xx: compile failure
- rtl18814au: compile failure
- rtl188xxau: compile failure
- v4l2loopback: compile failure
- xpadneo: negativo17 does not yet provide F40

I also standardized a small change to the build-kmod scripts. We now copy/activate extra yum repo files only after getting the Fedora release variable which make things simpler when needing to bail out early due to known issues with F40, etc.