### PR TITLE
fix: don't build certain kmods on kernel 6.8

### DIFF
--- a/build-kmod-gasket.sh
+++ b/build-kmod-gasket.sh
@@ -6,8 +6,8 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-if [ "40" == "${RELEASE}" ]; then
-  echo "SKIPPED BUILD of gasket: compile failure on F40 as of 2024-03-17"
+if [[ "${KERNEL}" =~ "6.8" ]]; then
+  echo "SKIPPED BUILD of rtl8814au: compile failure on kernel 6.8 as of 2024-03-17"
   exit 0
 fi
 

--- a/build-kmod-rtl8814au.sh
+++ b/build-kmod-rtl8814au.sh
@@ -6,7 +6,7 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-if [ "${KERNEL}" =~ "6.8" ]; then
+if [[ "${KERNEL}" =~ "6.8" ]]; then
   echo "SKIPPED BUILD of rtl8814au: compile failure on kernel 6.8 as of 2024-03-17"
   exit 0
 fi

--- a/build-kmod-rtl8814au.sh
+++ b/build-kmod-rtl8814au.sh
@@ -6,8 +6,8 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-if [ "40" == "${RELEASE}" ]; then
-  echo "SKIPPED BUILD of rtl8814au: compile failure on F40 as of 2024-03-17"
+if [ "${KERNEL}" =~ "6.8" ]; then
+  echo "SKIPPED BUILD of rtl8814au: compile failure on kernel 6.8 as of 2024-03-17"
   exit 0
 fi
 

--- a/build-kmod-rtl88xxau.sh
+++ b/build-kmod-rtl88xxau.sh
@@ -6,7 +6,7 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-if [ "${KERNEL}" =~ "6.8" ]; then
+if [[ "${KERNEL}" =~ "6.8" ]]; then
   echo "SKIPPED BUILD of rtl8814au: compile failure on kernel 6.8 as of 2024-03-17"
   exit 0
 fi

--- a/build-kmod-rtl88xxau.sh
+++ b/build-kmod-rtl88xxau.sh
@@ -6,8 +6,8 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-if [ "40" == "${RELEASE}" ]; then
-  echo "SKIPPED BUILD of rtl88xxau: compile failure on F40 as of 2024-03-17"
+if [ "${KERNEL}" =~ "6.8" ]; then
+  echo "SKIPPED BUILD of rtl8814au: compile failure on kernel 6.8 as of 2024-03-17"
   exit 0
 fi
 

--- a/build-kmod-rtl88xxau.sh
+++ b/build-kmod-rtl88xxau.sh
@@ -7,7 +7,7 @@ KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')
 RELEASE="$(rpm -E '%fedora')"
 
 if [[ "${KERNEL}" =~ "6.8" ]]; then
-  echo "SKIPPED BUILD of rtl8814au: compile failure on kernel 6.8 as of 2024-03-17"
+  echo "SKIPPED BUILD of rtl88xxau: compile failure on kernel 6.8 as of 2024-03-17"
   exit 0
 fi
 

--- a/build-kmod-v4l2loopback.sh
+++ b/build-kmod-v4l2loopback.sh
@@ -8,7 +8,7 @@ KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')
 RELEASE="$(rpm -E '%fedora')"
 
 if [[ "${KERNEL}" =~ "6.8" ]]; then
-  echo "SKIPPED BUILD of rtl8814au: compile failure on kernel 6.8 as of 2024-03-17"
+  echo "SKIPPED BUILD of v4l2loopback: compile failure on kernel 6.8 as of 2024-03-17"
   exit 0
 fi
 

--- a/build-kmod-v4l2loopback.sh
+++ b/build-kmod-v4l2loopback.sh
@@ -7,9 +7,8 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-
-if [ "40" == "${RELEASE}" ]; then
-  echo "SKIPPED BUILD of v4l2loopback: compile failure on F40 as of 2024-03-17"
+if [[ "${KERNEL}" =~ "6.8" ]]; then
+  echo "SKIPPED BUILD of rtl8814au: compile failure on kernel 6.8 as of 2024-03-17"
   exit 0
 fi
 


### PR DESCRIPTION
This disables 3 kmods which don't currently build on kernel 6.8:
- rtl8814au
- rtl88xxau
- v4l2loopback

These also happen to fail in F40, since it uses a 6.8 kernel already too.


F40 builds are failing for other reasons at this time and should not block merging of this PR.