### PR TITLE
fix: 3 kmods now work on F40

### DIFF
--- a/build-kmod-evdi.sh
+++ b/build-kmod-evdi.sh
@@ -7,11 +7,6 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-if [ "40" == "${RELEASE}" ]; then
-  echo "SKIPPED BUILD of evdi: negativo17 not supporting F40 yet"
-  exit 0
-fi
-
 cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo /etc/yum.repos.d/
 
 ### BUILD evdi (succeed or fail-fast with debug output)

--- a/build-kmod-v4l2loopback.sh
+++ b/build-kmod-v4l2loopback.sh
@@ -7,11 +7,6 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-if [[ "${KERNEL}" =~ "6.8" ]]; then
-  echo "SKIPPED BUILD of v4l2loopback: compile failure on kernel 6.8 as of 2024-03-17"
-  exit 0
-fi
-
 ### BUILD v4l2loopbak (succeed or fail-fast with debug output)
 rpm-ostree install \
     akmod-v4l2loopback-*.fc${RELEASE}.${ARCH}

--- a/build-kmod-xpadneo.sh
+++ b/build-kmod-xpadneo.sh
@@ -7,11 +7,6 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-if [ "40" == "${RELEASE}" ]; then
-  echo "SKIPPED BUILD of xpadneo: negativo17 not supporting F40 yet"
-  exit 0
-fi
-
 cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo /etc/yum.repos.d/
 
 ### BUILD xpadneo (succeed or fail-fast with debug output)


### PR DESCRIPTION
2 of these and negativo17 who now is supporting F40 in their repos.
v4l2loopback had  not been compiling on 6.8 but now is.