### PR TITLE
chore: disable v4l2loopback on surface and F38 surface

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -51,6 +51,8 @@ jobs:
           - kernel_flavor: asus
             fedora_version: 38
           - kernel_flavor: surface
+            fedora_version: 38
+          - kernel_flavor: surface
             nvidia_version: 470
           - fedora_version: 40
             nvidia_version: 470 # rpmfusion packages nvidia 470 for F40 but won't compile yet.

--- a/build-kmod-gasket.sh
+++ b/build-kmod-gasket.sh
@@ -7,7 +7,7 @@ KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')
 RELEASE="$(rpm -E '%fedora')"
 
 if [[ "${KERNEL}" =~ "6.8" ]]; then
-  echo "SKIPPED BUILD of rtl8814au: compile failure on kernel 6.8 as of 2024-03-17"
+  echo "SKIPPED BUILD of gasket: compile failure on kernel 6.8 as of 2024-03-17"
   exit 0
 fi
 

--- a/build-kmod-v4l2loopback.sh
+++ b/build-kmod-v4l2loopback.sh
@@ -7,6 +7,11 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
+if [[ "${KERNEL_FLAVOR}" =~ "surface" ]]; then
+  echo "SKIPPED BUILD of v4l2loopback: compile failure on surface kernel as of 2024-03-27"
+  exit 0
+fi
+
 ### BUILD v4l2loopbak (succeed or fail-fast with debug output)
 rpm-ostree install \
     akmod-v4l2loopback-*.fc${RELEASE}.${ARCH}


### PR DESCRIPTION
Surface kernel only supports latest.

For some reason v4l2loopback still failing to build on surface's kernel.
