### PR TITLE
chore(ci): fix some kmod build failures

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -56,6 +56,8 @@ jobs:
             nvidia_version: 470
           - fedora_version: 40
             nvidia_version: 470 # rpmfusion packages nvidia 470 for F40 but won't compile yet.
+          - fedora_version: 38
+            kernel_flavor: fsync # kernel-fsync not required for ublue-os F38
           - fedora_version: 40
             kernel_flavor: fsync # kernel-fsync packages are not being built for F40 yet.
           

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -57,7 +57,7 @@ jobs:
           - fedora_version: 40
             nvidia_version: 470 # rpmfusion packages nvidia 470 for F40 but won't compile yet.
           - fedora_version: 40
-            kernel_flavor: 6.7.9-207.fsync # kernel-fsync packages are not being built for F40 yet.
+            kernel_flavor: fsync # kernel-fsync packages are not being built for F40 yet.
           
     steps:
       # Checkout push-to-registry action GitHub repository

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -46,8 +46,10 @@ jobs:
             nvidia_version: 550
           - cfile_suffix: nvidia
             nvidia_version: 0
-          - kernel_flavor: 6.7.9-207.fsync
-            fedora_version: 38
+          - cfile_suffix: nvidia
+            fedora_version: 39
+            kernel_flavor: asus
+            nvidia_version: 470 # nvidia 470 no longer builds on 6.8 asus kernel
           - kernel_flavor: asus
             fedora_version: 38
           - kernel_flavor: surface

--- a/build-kmod-v4l2loopback.sh
+++ b/build-kmod-v4l2loopback.sh
@@ -7,8 +7,8 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-if [[ "${KERNEL_FLAVOR}" =~ "surface" ]]; then
-  echo "SKIPPED BUILD of v4l2loopback: compile failure on surface kernel as of 2024-03-27"
+if [[ "${RELEASE}" -eq "39" ]] && [[ "${KERNEL_FLAVOR}" != "main" ]]; then
+  echo "SKIPPED BUILD of v4l2loopback: compile failure on F39 w/ 6.8 kernels as of 2024-03-27"
   exit 0
 fi
 


### PR DESCRIPTION
Fixes:
- catchup exclude with fsync version change
- don't build fsync for F38
- allow v4l2loopback builds on 6.8, but not custom F39