### PR TITLE
fix: docs: fix contributor's guide 404 link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,3 @@
 ## Thank you for contributing to the Universal Blue project!
 
-Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.
+Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.


### PR DESCRIPTION
Quick PR template fix for contributor's guide. Note: the link on that page for the code of conduct is also a 404. Currently it is pointing at https://universal-blue.org/CODE_OF_CONDUCT.md