### PR TITLE
chore: support new fedora 6.8.4 main kernel

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -37,27 +37,16 @@ jobs:
           - nvidia
         nvidia_version:
           - 0
-          - 470
           - 550
         exclude:
-          - cfile_suffix: common
-            nvidia_version: 470
           - cfile_suffix: common
             nvidia_version: 550
           - cfile_suffix: nvidia
             nvidia_version: 0
-          - cfile_suffix: nvidia
-            fedora_version: 39
-            kernel_flavor: asus
-            nvidia_version: 470 # nvidia 470 no longer builds on 6.8 asus kernel
           - kernel_flavor: asus
             fedora_version: 38
           - kernel_flavor: surface
             fedora_version: 38
-          - kernel_flavor: surface
-            nvidia_version: 470
-          - fedora_version: 40
-            nvidia_version: 470 # rpmfusion packages nvidia 470 for F40 but won't compile yet.
           - fedora_version: 38
             kernel_flavor: fsync # kernel-fsync not required for ublue-os F38
           - fedora_version: 40

--- a/README.md
+++ b/README.md
@@ -40,18 +40,21 @@ The [`akmods` image](https://github.com/orgs/ublue-os/packages/container/package
 
 Here's a rundown on how it's organized.
 
-We do our best to support all current builds of Fedora, current versions of the kernel modules listed, and in the case of NVIDIA, current (550) and the 470 legacy driver.
+We do our best to support all current builds of Fedora, current versions of the kernel modules listed, and in the case of NVIDIA current (550).
+**Note: NVIDIA legacy driver version 470 is no longer provided as RPMfusion has ceased updates to the package and it no longer builds with kernel 6.8 which has now released for Fedora 38 and 39.**
 
 The majority of the drivers are tagged with `KERNEL_TYPE-FEDORA_RELEASE`. NVIDIA drivers are bundled distinctly with tag `KERNEL_TYPE-FEDORA_RELEASE-NVIDIA_VERSION`.
 
 | KERNEL_TYPE | FEDORA_RELEASE | TAG |
 | - | - | - |
-| Fedora stock kernel | 38 | `main-38`, `main-38-470` `main-38-550` |
-| | 39 | `main-39`, `main-39-470` `main-39-550` |
-| [patched for ASUS devices](https://copr.fedorainfracloud.org/coprs/lukenukem/asus-kernel) | 38 | `asus-38`, `asus-38-470` `asus-38-550` |
-| | 39 | `asus-39`, `asus-39-470` `asus-39-550` |
-| [patched Microsoft Surface devices](https://github.com/linux-surface/linux-surface/) | 38 | `surface-38`, `surface-38-550` |
-| | 39 | `surface-39`, `surface-39-550` |
+| Fedora stock kernel | 38 | `main-38`, `main-38-550` |
+| | 39 | `main-39`, `main-39-550` |
+| | 40 | `main-40`, `main-40-550` |
+| [patched for ASUS devices](https://copr.fedorainfracloud.org/coprs/lukenukem/asus-kernel) | 39 | `asus-39`, `asus-39-550` |
+| | 40 | `asus-40`, `asus-40-550` |
+| [patched fsync](https://copr.fedorainfracloud.org/coprs/sentry/kernel-fsync) | 39 | `fsync-39`, `fsync-39-550` |
+| [patched Microsoft Surface devices](https://github.com/linux-surface/linux-surface/) | 39 | `surface-39`, `surface-39-550` |
+| | 40 | `surface-40`, `surface-40-550` |
 
 
 

--- a/build-kmod-v4l2loopback.sh
+++ b/build-kmod-v4l2loopback.sh
@@ -7,8 +7,8 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-if [[ "${RELEASE}" -eq "39" ]] && [[ "${KERNEL_FLAVOR}" != "main" ]]; then
-  echo "SKIPPED BUILD of v4l2loopback: compile failure on F39 w/ 6.8 kernels as of 2024-03-27"
+if [[ "${RELEASE}" -lt "40" ]]; then
+  echo "SKIPPED BUILD of v4l2loopback: compile failure on 6.8 kernels in F38/F39 as of 2024-03-27"
   exit 0
 fi
 


### PR DESCRIPTION
Attempting to get akmods building again, at least most of them. #144 is tracking the kmod build gaps, eg, 4 kmods not happy with 6.8 or F40.

- remove nvidia 470 due to rpmfusion dropping support
- no build of v4l2loopback on F38/F39 due to kernel 6.8 problems

