### PR TITLE
fix: restore v4l2loopback build

### DIFF
--- a/build-kmod-v4l2loopback.sh
+++ b/build-kmod-v4l2loopback.sh
@@ -7,11 +7,6 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-if [[ "${RELEASE}" -lt "40" ]]; then
-  echo "SKIPPED BUILD of v4l2loopback: compile failure on 6.8 kernels in F38/F39 as of 2024-03-27"
-  exit 0
-fi
-
 ### BUILD v4l2loopbak (succeed or fail-fast with debug output)
 rpm-ostree install \
     akmod-v4l2loopback-*.fc${RELEASE}.${ARCH}


### PR DESCRIPTION
This will merge when it builds cleanly, after rpmfusion migrates the new package from updates-testing to updates repo. 
This will be apparent when:
1) this builds
2) `v4l2loopback` is present here: https://mirror.fcix.net/rpmfusion/free/fedora/updates/39/x86_64/repoview/letter_v.group.html OR "tag" changes to "f39-free-updates" (from testing) here https://koji.rpmfusion.org/koji/buildinfo?buildID=28538

Relates: #144
