### PR TITLE
fix: only copy dkms keys for coreos

### DIFF
--- a/build-prep.sh
+++ b/build-prep.sh
@@ -156,8 +156,10 @@ fi
 install -Dm644 /tmp/certs/public_key.der   /etc/pki/akmods/certs/public_key.der
 install -Dm644 /tmp/certs/private_key.priv /etc/pki/akmods/private/private_key.priv
 
-install -Dm644 /tmp/certs/public_key.der /lib/modules/${KERNEL_VERSION}/build/certs/signing_key.x509
-install -Dm644 /tmp/certs/private_key.priv /lib/modules/${KERNEL_VERSION}/build/certs/signing_key.pem
+if [[ "coreos" == "${KERNEL_FLAVOR}" ]]; then
+    install -Dm644 /tmp/certs/public_key.der /lib/modules/${KERNEL_VERSION}.x86_64/build/certs/signing_key.x509
+    install -Dm644 /tmp/certs/private_key.priv /lib/modules/${KERNEL_VERSION}.x86_64/build/certs/signing_key.pem
+fi
 
 # protect against incorrect permissions in tmp dirs which can break akmods builds
 chmod 1777 /tmp /var/tmp


### PR DESCRIPTION
Coreos is the only flavor that builds a dkms module. Additionally it's KERNEL_VERSION does not contain .x86_64.

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.
