### PR TITLE
fix(nvidia): use vulkan renderer by default to mitigate flickering

### DIFF
--- a/files/etc/sway/environment
+++ b/files/etc/sway/environment
@@ -14,14 +14,14 @@ SWAY_EXTRA_ARGS="$SWAY_EXTRA_ARGS --unsupported-gpu -D noscanout"
 
 # Useful variables for wlroots:
 # https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/docs/env_vars.md
-#
-#WLR_NO_HARDWARE_CURSORS=1
 WLR_NO_HARDWARE_CURSORS=1
 # Setting renderer to Vulkan may fix flickering but needs the following extensions:
 # - VK_EXT_image_drm_format_modifier
 # - VK_EXT_physical_device_drm
 #
 # Source: https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/8e346922508aa3eaccd6e12f2917f6574f349843
-#WLR_RENDERER=vulkan
+WLR_RENDERER=vulkan
 
-# Application compatibility
+# Java Application compatibility
+# Source: https://github.com/swaywm/wlroots/issues/1464
+_JAVA_AWT_WM_NONREPARENTING=1


### PR DESCRIPTION
Recently flickering on sericea-nvidia was reported in the HWE repo: https://github.com/ublue-os/hwe/issues/260. A workaround or "fix" for a large amount of the flickering on sway is to switch to the vulkan renderer, the nvidia GPUs we support also support the vulkan required extensions and version.
I also added an environment variable that fixes some java applications: _JAVA_AWT_WM_NONREPARENTING=1

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.
