### PR TITLE
feat: build both stable and testing CoreOS streams

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -33,7 +33,8 @@ jobs:
           - fsync
           - fsync-lts
           - surface
-          - coreos
+          - coreos-stable
+          - coreos-testing
         cfile_suffix:
           - common
           - extra
@@ -164,8 +165,9 @@ jobs:
                 $dnf config-manager --add-repo=https://pkg.surfacelinux.com/fedora/linux-surface.repo
                 linux=$($dnf repoquery --repoid linux-surface --whatprovides kernel-surface | tail -n1 | sed 's/.*://')
                 ;;
-              "coreos")
-                coreos_kernel_release=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:stable | jq -r '.Labels["ostree.linux"] | split(".x86_64")[0]')
+              "coreos-stable"|"coreos-testing"")
+                coreos_stream=$(echo "${{ matrix.kernel_flavor }}" | cut -f2 -d-)
+                coreos_kernel_release=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:${coreos_stream} | jq -r '.Labels["ostree.linux"] | split(".x86_64")[0]')
                 coreos_fedora_version=$(echo $coreos_kernel_release | grep -oP 'fc\K[0-9]+')
                 if [[ "${{ matrix.fedora_version }}" == "$coreos_fedora_version" ]]; then
                     linux="${coreos_kernel_release}"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -123,7 +123,6 @@ jobs:
             podman pull ${{ env.FQ_SOURCE_IMAGE }}
 
       - name: Get current version
-        shell: bash
         run: |
           set -eo pipefail
 
@@ -166,7 +165,7 @@ jobs:
                 $dnf config-manager --add-repo=https://pkg.surfacelinux.com/fedora/linux-surface.repo
                 linux=$($dnf repoquery --repoid linux-surface --whatprovides kernel-surface | tail -n1 | sed 's/.*://')
                 ;;
-              "coreos-stable"|"coreos-testing"")
+              "coreos-stable"|"coreos-testing")
                 coreos_stream=$(echo "${{ matrix.kernel_flavor }}" | cut -f2 -d-)
                 coreos_kernel_release=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:${coreos_stream} | jq -r '.Labels["ostree.linux"] | split(".x86_64")[0]')
                 coreos_fedora_version=$(echo $coreos_kernel_release | grep -oP 'fc\K[0-9]+')

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -123,6 +123,7 @@ jobs:
             podman pull ${{ env.FQ_SOURCE_IMAGE }}
 
       - name: Get current version
+        shell: bash
         run: |
           set -eo pipefail
 

--- a/build-prep.sh
+++ b/build-prep.sh
@@ -106,7 +106,7 @@ elif [[ "surface" == "${KERNEL_FLAVOR}" ]]; then
         --install kernel-surface-modules \
         --install kernel-surface-modules-core \
         --install kernel-surface-modules-extra
-elif [[ "coreos" == "${KERNEL_FLAVOR}" ]] && \
+elif [[ "${KERNEL_FLAVOR}" =~ "coreos" ]] && \
      [[ -n "${KERNEL_VERSION}" ]]; then
     echo "Installing CoreOS Kernel"
     KERNEL_MAJOR_MINOR_PATCH=$(echo $KERNEL_VERSION | cut -d '-' -f 1)
@@ -156,7 +156,7 @@ fi
 install -Dm644 /tmp/certs/public_key.der   /etc/pki/akmods/certs/public_key.der
 install -Dm644 /tmp/certs/private_key.priv /etc/pki/akmods/private/private_key.priv
 
-if [[ "coreos" == "${KERNEL_FLAVOR}" ]]; then
+if [[ "${KERNEL_FLAVOR}" =~ "coreos" ]]; then
     install -Dm644 /tmp/certs/public_key.der /lib/modules/${KERNEL_VERSION}.x86_64/build/certs/signing_key.x509
     install -Dm644 /tmp/certs/private_key.priv /lib/modules/${KERNEL_VERSION}.x86_64/build/certs/signing_key.pem
 fi


### PR DESCRIPTION
This provides both kernel streams for uCore or other CoreOS images to consume.

A breaking change occurs in the tagging for existing coreos akmods images.

Instead of: `akmods:coreos-40` and `akmods:coreos-39` this will build
 `akmods:coreos-stable-40` and `akmods:coreos-stable-39`.