### PR TITLE
refactor: split zfs into distinct image

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -38,11 +38,7 @@ jobs:
           - common
           - extra
           - nvidia
-        include:
-          - kernel_flavor: coreos-stable
-            cfile_suffix: zfs
-          - kernel_flavor: coreos-testing
-            cfile_suffix: zfs
+          - zfs
         exclude:
           - fedora_version: 39
             kernel_flavor: fsync
@@ -50,6 +46,14 @@ jobs:
             kernel_flavor: asus
           - fedora_version: 39
             kernel_flavor: coreos-testing
+          - kernel_flavor: main
+            cfile_suffix: zfs
+          - kernel_flavor: asus
+            cfile_suffix: zfs
+          - kernel_flavor: fsync
+            cfile_suffix: zfs
+          - kernel_flavor: surface
+            cfile_suffix: zfs
 
     steps:
       # Checkout push-to-registry action GitHub repository

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -38,6 +38,11 @@ jobs:
           - common
           - extra
           - nvidia
+        include:
+          - kernel_flavor: coreos-stable
+            cfile_suffix: zfs
+          - kernel_flavor: coreos-testing
+            cfile_suffix: zfs
         exclude:
           - fedora_version: 39
             kernel_flavor: fsync

--- a/Containerfile.common
+++ b/Containerfile.common
@@ -48,12 +48,7 @@ RUN if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
     /tmp/build-kmod-v4l2loopback.sh && \
     /tmp/build-kmod-wl.sh && \
     /tmp/build-kmod-xpadneo.sh && \
-    /tmp/build-kmod-xone.sh && \
-    if grep -q "coreos" <<< "${KERNEL_FLAVOR}"; then \
-        curl -Lo /tmp/zfs-minor-version "https://raw.githubusercontent.com/ublue-os/ucore-kmods/main/Containerfile" && \
-        zfs_minor_version=$(grep "ZFS_MINOR_VERSION" /tmp/zfs-minor-version | cut -d "-" -f 2 | cut -d \} -f 1) && \
-        ZFS_MINOR_VERSION="$zfs_minor_version" /tmp/build-kmod-zfs.sh \
-    ; fi
+    /tmp/build-kmod-xone.sh
 
 RUN cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm \
       /var/cache/rpms/ublue-os/

--- a/Containerfile.zfs
+++ b/Containerfile.zfs
@@ -24,12 +24,8 @@ COPY certs /tmp/certs
 COPY --from=kernel_cache /tmp/rpms /tmp/kernel_cache
 
 # Set kernel name
-RUN if grep -q "coreos" <<< "${KERNEL_FLAVOR}"; then \
-        /tmp/build-prep.sh && \
-        /tmp/build-kmod-zfs.sh \
-    ; else \
-        echo "Error: ublue only builds ZFS for CoreOS kernels." \
-    ; fi
+RUN /tmp/build-prep.sh && \
+    /tmp/build-kmod-zfs.sh
 
 RUN for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
         cp "${RPM}" /var/cache/rpms/kmods/; \

--- a/Containerfile.zfs
+++ b/Containerfile.zfs
@@ -1,0 +1,42 @@
+###
+### Containerfile.common - used to build ONLY NON-nvidia kmods
+###
+
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-40}"
+ARG KERNEL_FLAVOR="${KERNEL_FLAVOR:-coreos-stable}"
+ARG KERNEL_IMAGE="${KERNEL_IMAGE:-${KERNEL_FLAVOR}-kernel}"
+ARG KERNEL_ORG="${KERNEL_ORG:-ublue-os}"
+ARG KERNEL_BASE="ghcr.io/${KERNEL_ORG}/${KERNEL_IMAGE}:${FEDORA_MAJOR_VERSION}"
+ARG BUILDER_IMAGE="${BUILDER_IMAGE:-quay.io/fedora/fedora}"
+ARG BUILDER_BASE="${BUILDER_IMAGE}:${FEDORA_MAJOR_VERSION}"
+FROM ${KERNEL_BASE} AS kernel_cache
+FROM ${BUILDER_BASE} AS builder
+
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-40}"
+ARG KERNEL_FLAVOR="${KERNEL_FLAVOR:-coreos-stable}"
+ARG RPMFUSION_MIRROR=""
+ARG ZFS_MINOR_VERSION="${ZFS_MINOR_VERSION:-2.2}"
+
+COPY build*.sh /tmp
+COPY certs /tmp/certs
+
+# cached kernel rpms
+COPY --from=kernel_cache /tmp/rpms /tmp/kernel_cache
+
+# Set kernel name
+RUN if grep -q "coreos" <<< "${KERNEL_FLAVOR}"; then \
+        /tmp/build-prep.sh && \
+        /tmp/build-kmod-zfs.sh \
+    ; else \
+        echo "Error: ublue only builds ZFS for CoreOS kernels." \
+    ; fi
+
+RUN for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
+        cp "${RPM}" /var/cache/rpms/kmods/; \
+    done
+
+RUN find /var/cache/rpms
+
+FROM scratch
+
+COPY --from=builder /var/cache/rpms /rpms

--- a/Containerfile.zfs
+++ b/Containerfile.zfs
@@ -1,5 +1,5 @@
 ###
-### Containerfile.common - used to build ONLY NON-nvidia kmods
+### Containerfile.zfs - used to build ONLY ZFS kmod
 ###
 
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-40}"


### PR DESCRIPTION
Initially ZFS support was added as part of the akmods common image and corresponding workflow matrix element.

This splits ZFS support into a distinct:
- workflow matrix element (distinct build)
- Containerfile
- final image
