### PR TITLE
refactor: move ucore addons builds here

### DIFF
--- a/Containerfile.common
+++ b/Containerfile.common
@@ -25,6 +25,7 @@ COPY --from=kernel_cache /tmp/rpms /tmp/kernel_cache
 
 # files for akmods
 COPY ublue-os-akmods-addons.spec /tmp/ublue-os-akmods-addons/ublue-os-akmods-addons.spec
+COPY ublue-os-ucore-addons.spec /tmp/ublue-os-ucore-addons/ublue-os-ucore-addons.spec
 ADD https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/repo/fedora-${FEDORA_MAJOR_VERSION}/ublue-os-akmods-fedora-${FEDORA_MAJOR_VERSION}.repo \
     /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo
 ADD https://negativo17.org/repos/fedora-multimedia.repo \
@@ -32,7 +33,14 @@ ADD https://negativo17.org/repos/fedora-multimedia.repo \
 
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \
+    if [[ "${KERNEL_FLAVOR}" =~ "coreos" ]]; then \
+      /tmp/build-ublue-os-ucore-addons.sh && \
+      cp /tmp/ublue-os-ucore-addons/rpmbuild/RPMS/noarch/ublue-os-ucore-addons*.rpm \
+        /var/cache/rpms/ucore/ \
+    ; fi && \
     /tmp/build-ublue-os-akmods-addons.sh && \
+    cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm \
+      /var/cache/rpms/ublue-os/ && \
     if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
         export KERNEL_NAME="kernel" \
     ; else \
@@ -49,8 +57,6 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-kmod-xpadneo.sh && \
     /tmp/build-kmod-xone.sh && \
     /tmp/dual-sign.sh && \
-    cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm \
-      /var/cache/rpms/ublue-os/ && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
         cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \

--- a/Containerfile.nvidia
+++ b/Containerfile.nvidia
@@ -25,14 +25,24 @@ COPY --from=kernel_cache /tmp/rpms /tmp/kernel_cache
 
 # files for nvidia
 COPY ublue-os-nvidia-addons.spec /tmp/ublue-os-nvidia-addons/ublue-os-nvidia-addons.spec
+COPY ublue-os-ucore-nvidia.spec /tmp/ublue-os-ucore-nvidia/ublue-os-ucore-nvidia.spec
 COPY files/etc/sway/environment /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/environment
 COPY files/usr/lib/systemd/system/ublue-nvctk-cdi.service /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/ublue-nvctk-cdi.service
+COPY files/usr/lib/systemd/system/ublue-nvctk-cdi.service /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/ublue-nvctk-cdi.service
 COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/70-ublue-nvctk-cdi.preset
+COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/70-ublue-nvctk-cdi.preset
 
 
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \
+    if [[ "${KERNEL_FLAVOR}" =~ "coreos" ]]; then \
+      /tmp/build-ublue-os-ucore-nvidia.sh && \
+      cp /tmp/ublue-os-ucore-nvidia/rpmbuild/RPMS/noarch/ublue-os-ucore-nvidia*.rpm \
+        /var/cache/rpms/ucore/ \
+    ; fi && \
     /tmp/build-ublue-os-nvidia-addons.sh && \
+    cp /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons*.rpm \
+      /var/cache/rpms/ublue-os/ && \
     if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
        export KERNEL_NAME="kernel" \
     ; else \
@@ -40,8 +50,6 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
     ; fi && \
     /tmp/build-kmod-nvidia.sh 550 && \
     /tmp/dual-sign.sh && \
-    cp /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons*.rpm \
-      /var/cache/rpms/ublue-os/ && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
         cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \

--- a/build-prep.sh
+++ b/build-prep.sh
@@ -93,4 +93,4 @@ fi
 chmod 1777 /tmp /var/tmp
 
 # create directories for later copying resulting artifacts
-mkdir -p /var/cache/rpms/{kmods,ublue-os}
+mkdir -p /var/cache/rpms/{kmods,ublue-os,ucore}

--- a/build-ublue-os-ucore-addons.sh
+++ b/build-ublue-os-ucore-addons.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+### BUILD UCORE-ADDONS RPM
+install -D /etc/pki/akmods/certs/public_key.der /tmp/ublue-os-ucore-addons/rpmbuild/SOURCES/public_key.der
+rpmbuild -ba \
+    --define '_topdir /tmp/ublue-os-ucore-addons/rpmbuild' \
+    --define '%_tmppath %{_topdir}/tmp' \
+    /tmp/ublue-os-ucore-addons/ublue-os-ucore-addons.spec

--- a/build-ublue-os-ucore-nvidia.sh
+++ b/build-ublue-os-ucore-nvidia.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+### SETUP nvidia container stuffs
+
+mkdir -p /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/
+
+curl -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo \
+    -o /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/nvidia-container-toolkit.repo
+sed -i "s@gpgcheck=0@gpgcheck=1@" /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/nvidia-container-toolkit.repo
+
+curl -L https://raw.githubusercontent.com/NVIDIA/dgx-selinux/master/bin/RHEL9/nvidia-container.pp \
+    -o /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/nvidia-container.pp
+
+rpmbuild -ba \
+    --define '_topdir /tmp/ublue-os-ucore-nvidia/rpmbuild' \
+    --define '%_tmppath %{_topdir}/tmp' \
+    /tmp/ublue-os-ucore-nvidia/ublue-os-ucore-nvidia.spec

--- a/ublue-os-nvidia-addons.spec
+++ b/ublue-os-nvidia-addons.spec
@@ -4,18 +4,18 @@ Release:        1%{?dist}
 Summary:        Additional files for nvidia driver support
 
 License:        MIT
-URL:            https://github.com/ublue-os/nvidia
+URL:            https://github.com/ublue-os/akmods
 
 BuildArch:      noarch
 Supplements:    mokutil policycoreutils
 
 Source0:        nvidia-container-toolkit.repo
-Source1:        eyecantcu-supergfxctl.repo
-Source2:        nvidia-container.pp
-Source3:        environment
-Source4:        ublue-nvctk-cdi.service
-Source5:        70-ublue-nvctk-cdi.preset
-Source6:        negativo17-fedora-nvidia.repo
+Source1:        nvidia-container.pp
+Source2:        ublue-nvctk-cdi.service
+Source3:        70-ublue-nvctk-cdi.preset
+Source4:        environment
+Source5:        negativo17-fedora-nvidia.repo
+Source6:        eyecantcu-supergfxctl.repo
 
 %description
 Adds various runtime files for nvidia support.
@@ -25,21 +25,21 @@ Adds various runtime files for nvidia support.
 
 
 %build
-install -Dm0644 %{SOURCE6} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-nvidia.repo
 install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
-install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
-install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
-install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/sway/environment
-install -Dm0644 %{SOURCE4} %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service
-install -Dm0644 %{SOURCE5} %{buildroot}%{_presetdir}/70-ublue-nvctk-cdi.preset
+install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
+install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service
+install -Dm0644 %{SOURCE3} %{buildroot}%{_presetdir}/70-ublue-nvctk-cdi.preset
+install -Dm0644 %{SOURCE4} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/sway/environment
+install -Dm0644 %{SOURCE5} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-nvidia.repo
+install -Dm0644 %{SOURCE6} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 
+sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-nvidia.repo
 sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
-sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
 
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-nvidia.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/negativo17-fedora-nvidia.repo
-install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo        %{buildroot}%{_sysconfdir}/yum.repos.d/eyecantcu-supergfxctl.repo
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp             %{buildroot}%{_datadir}/selinux/packages/nvidia-container.pp
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service                          %{buildroot}%{_unitdir}/ublue-nvctk-cdi.service
 

--- a/ublue-os-ucore-addons.spec
+++ b/ublue-os-ucore-addons.spec
@@ -1,0 +1,33 @@
+Name:           ublue-os-ucore-addons
+Version:        0.1
+Release:        1%{?dist}
+Summary:        Signing key for ucore kmods
+
+License:        MIT
+URL:            https://github.com/ublue-os/ucore-kmods
+
+BuildArch:      noarch
+Supplements:    mokutil policycoreutils
+
+Source0:        public_key.der
+
+%description
+Adds the signing key for importing with mokutil to enable secure boot for kernel modules.
+
+%prep
+%setup -q -c -T
+
+
+%build
+# Have different name for *.der in case kmodgenca is needed for creating more keys
+install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
+
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der            %{buildroot}%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
+
+%files
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
+%attr(0644,root,root) %{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
+
+%changelog
+* Sat Dec 30 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.1
+- Add key for enrolling ucore kernel modules for secure boot

--- a/ublue-os-ucore-nvidia.spec
+++ b/ublue-os-ucore-nvidia.spec
@@ -1,0 +1,57 @@
+Name:           ublue-os-ucore-nvidia
+Version:        0.3
+Release:        1%{?dist}
+Summary:        Additional files for nvidia driver support on CoreOS
+
+License:        MIT
+URL:            https://github.com/ublue-os/akmods
+
+BuildArch:      noarch
+Supplements:    mokutil policycoreutils
+
+Source0:        nvidia-container-toolkit.repo
+Source1:        nvidia-container.pp
+Source2:        ublue-nvctk-cdi.service
+Source3:        70-ublue-nvctk-cdi.preset
+
+%description
+Adds various runtime files for nvidia support on Fedora CoreOS.
+
+%prep
+%setup -q -c -T
+
+
+%build
+install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
+install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
+install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service
+install -Dm0644 %{SOURCE3} %{buildroot}%{_presetdir}/70-ublue-nvctk-cdi.preset
+
+sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
+
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp             %{buildroot}%{_datadir}/selinux/packages/nvidia-container.pp
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service                          %{buildroot}%{_unitdir}/ublue-nvctk-cdi.service
+
+%files
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service
+%attr(0644,root,root) %{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
+%attr(0644,root,root) %{_datadir}/selinux/packages/nvidia-container.pp
+%attr(0644,root,root) %{_unitdir}/ublue-nvctk-cdi.service
+%attr(0644,root,root) %{_presetdir}/70-ublue-nvctk-cdi.preset
+
+%changelog
+* Fri Oct 6 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.3
+- add ublue-nvctk-cdi service to auto-generate NVIDIA CDI GPU definitions
+
+* Wed Oct 04 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.2
+- use newer nvidia-container-toolkit repo
+- repo provides newer toolkit, no longer requires config.toml
+
+* Sat Aug 19 2023 Benjamin Sherman <benjamin@holyarmy.org> - 0.1
+First release for Fedora CoreOS based on ublue-os-nvidia-addons includes:
+- nvidia-container-runtime repo
+- nvidia-container-runtime rootless config
+- nvidia-container-runtime selinux policy file


### PR DESCRIPTION
This relocates the ucore-addons and ucore-nvidia RPM builds from ublue-os/ucore-kmods to ublue-os/akmods, allowing us to continue consolidating our build processes into more managable units.

Note: these ucore addons only build when the kernel flavor is set to coreos.

