### PR TITLE
feat: build nvidia open source kernel module

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -38,6 +38,7 @@ jobs:
           - common
           - extra
           - nvidia
+          - nvidia-open
           - zfs
         exclude:
           - fedora_version: 39

--- a/Containerfile.nvidia
+++ b/Containerfile.nvidia
@@ -48,7 +48,7 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
     ; else \
        export KERNEL_NAME="kernel-surface" \
     ; fi && \
-    /tmp/build-kmod-nvidia.sh closed && \
+    /tmp/build-kmod-nvidia.sh kernel && \
     /tmp/dual-sign.sh && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
         cp "${RPM}" /var/cache/rpms/kmods/; \

--- a/Containerfile.nvidia-open
+++ b/Containerfile.nvidia-open
@@ -48,7 +48,7 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
     ; else \
        export KERNEL_NAME="kernel-surface" \
     ; fi && \
-    /tmp/build-kmod-nvidia.sh closed && \
+    /tmp/build-kmod-nvidia.sh open && \
     /tmp/dual-sign.sh && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
         cp "${RPM}" /var/cache/rpms/kmods/; \

--- a/Containerfile.nvidia-open
+++ b/Containerfile.nvidia-open
@@ -48,7 +48,7 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
     ; else \
        export KERNEL_NAME="kernel-surface" \
     ; fi && \
-    /tmp/build-kmod-nvidia.sh open && \
+    /tmp/build-kmod-nvidia.sh kernel-open && \
     /tmp/dual-sign.sh && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
         cp "${RPM}" /var/cache/rpms/kmods/; \

--- a/build-kmod-nvidia.sh
+++ b/build-kmod-nvidia.sh
@@ -22,7 +22,9 @@ KERNEL_VERSION="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%
 NVIDIA_AKMOD_VERSION="$(basename "$(rpm -q "akmod-nvidia" --queryformat '%{VERSION}-%{RELEASE}')" ".fc${RELEASE%%.*}")"
 
 if [[ "${KERNEL_MODULE_TYPE}" == "open" ]]; then
-    sed -i -e 's/kernel$/kernel-open/g' /etc/nvidia/kernel.conf
+    sed -i "s/^MODULE_VARIANT=.*/MODULE_VARIANT=kernel-open/" /etc/nvidia/kernel.conf
+else
+    sed -i "s/^MODULE_VARIANT=.*/MODULE_VARIANT=kernel/" /etc/nvidia/kernel.conf
 fi
 
 akmods --force --kernels "${KERNEL_VERSION}" --kmod "nvidia"

--- a/build-kmod-nvidia.sh
+++ b/build-kmod-nvidia.sh
@@ -21,6 +21,9 @@ rpm -qa |grep nvidia
 KERNEL_VERSION="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 NVIDIA_AKMOD_VERSION="$(basename "$(rpm -q "akmod-nvidia" --queryformat '%{VERSION}-%{RELEASE}')" ".fc${RELEASE%%.*}")"
 
+if [[ "${KERNEL_MODULE_TYPE}" == "open" ]]; then
+    sed -i -e 's/kernel$/kernel-open/g' /etc/nvidia/kernel.conf
+fi
 
 akmods --force --kernels "${KERNEL_VERSION}" --kmod "nvidia"
 

--- a/build-kmod-nvidia.sh
+++ b/build-kmod-nvidia.sh
@@ -3,7 +3,7 @@
 set -oeux pipefail
 
 RELEASE="$(rpm -E '%fedora.%_arch')"
-KERNEL_MODULE_TYPE="$1"
+KERNEL_MODULE_TYPE="${1:-kernel}"
 
 cd /tmp
 
@@ -21,11 +21,7 @@ rpm -qa |grep nvidia
 KERNEL_VERSION="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 NVIDIA_AKMOD_VERSION="$(basename "$(rpm -q "akmod-nvidia" --queryformat '%{VERSION}-%{RELEASE}')" ".fc${RELEASE%%.*}")"
 
-if [[ "${KERNEL_MODULE_TYPE}" == "open" ]]; then
-    sed -i "s/^MODULE_VARIANT=.*/MODULE_VARIANT=kernel-open/" /etc/nvidia/kernel.conf
-else
-    sed -i "s/^MODULE_VARIANT=.*/MODULE_VARIANT=kernel/" /etc/nvidia/kernel.conf
-fi
+sed -i "s/^MODULE_VARIANT=.*/MODULE_VARIANT=$KERNEL_MODULE_TYPE/" /etc/nvidia/kernel.conf
 
 akmods --force --kernels "${KERNEL_VERSION}" --kmod "nvidia"
 

--- a/build-kmod-nvidia.sh
+++ b/build-kmod-nvidia.sh
@@ -3,6 +3,7 @@
 set -oeux pipefail
 
 RELEASE="$(rpm -E '%fedora.%_arch')"
+KERNEL_MODULE_TYPE="$1"
 
 cd /tmp
 
@@ -33,7 +34,7 @@ mkdir -p /var/cache/rpms/kmods/nvidia
 
 cat <<EOF > /var/cache/rpms/kmods/nvidia-vars
 KERNEL_VERSION=${KERNEL_VERSION}
+KERNEL_MODULE_TYPE=${KERNEL_MODULE_TYPE}
 RELEASE=${RELEASE}
 NVIDIA_AKMOD_VERSION=${NVIDIA_AKMOD_VERSION}
 EOF
-

--- a/build-kmod-nvidia.sh
+++ b/build-kmod-nvidia.sh
@@ -27,6 +27,8 @@ akmods --force --kernels "${KERNEL_VERSION}" --kmod "nvidia"
 modinfo /usr/lib/modules/${KERNEL_VERSION}/extra/nvidia/nvidia{,-drm,-modeset,-peermem,-uvm}.ko.xz > /dev/null || \
 (cat /var/cache/akmods/nvidia/${NVIDIA_AKMOD_VERSION}-for-${KERNEL_VERSION}.failed.log && exit 1)
 
+# View license information
+modinfo -l /usr/lib/modules/${KERNEL_VERSION}/extra/nvidia/nvidia{,-drm,-modeset,-peermem,-uvm}.ko.xz
 
 # create a directory for later copying of resulting nvidia specific artifacts
 mkdir -p /var/cache/rpms/kmods/nvidia


### PR DESCRIPTION
Enable the open kernel module builds.
This should not affect anything downstream.  Just gets us ready for the switch next Nvidia driver release.

Please note: I have not yet tried booting into an image with this driver.