### PR TITLE
feat(ci): Use kernel_version as a build tag

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -136,7 +136,7 @@ jobs:
           COMMIT_TAGS+=("pr-${{ github.event.number }}-${VARIANT}")
           COMMIT_TAGS+=("${SHA_SHORT}-${VARIANT}")
 
-          BUILD_TAGS=("${VARIANT}" "${VARIANT}-${TIMESTAMP}")
+          BUILD_TAGS=("${VARIANT}" "${VARIANT}-${TIMESTAMP}" "${VARIANT}-${KERNEL_VERSION}")
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
               echo "Generated the following commit tags: "


### PR DESCRIPTION
Matches a change in kernel-cache at: https://github.com/ublue-os/kernel-cache/pull/25

Makes selecting a specific kernel version much easier