### PR TITLE
chore(ci): restore fsync builds

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -30,6 +30,7 @@ jobs:
         kernel_flavor:
           - main
           - asus
+          - fsync
           - fsync-ba
           - surface
           - coreos-stable


### PR DESCRIPTION
The recent #231 PR replaced fsync with fsync-ba builds, breaking some downstreams, including bluefin.
