### PR TITLE
Create build-kmod-rtl8821au.sh

### DIFF
--- a/build-kmod-rtl8821au.sh
+++ b/build-kmod-rtl8821au.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+if [[ "${KERNEL}" =~ "6.8" ]]; then
+  echo "SKIPPED BUILD of rtl8814au: compile failure on kernel 6.8 as of 2024-03-17"
+  exit 0
+fi
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
+
+dnf install -y \
+    akmod-rtl8821au-*.fc${RELEASE}.${ARCH}
+akmods --force --kernels "${KERNEL}" --kmod rtl8821au
+modinfo /usr/lib/modules/${KERNEL}/extra/rtl8821au/rtl8821au.ko.xz > /dev/null \
+|| (find /var/cache/akmods/rtl8821au/ -name \*.log -print -exec cat {} \; && exit 1)
+
+rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo


### PR DESCRIPTION
Hello! This PR adds support for rtl8821au based on the [build-kmod-rtl8814au.sh](https://github.com/ublue-os/akmods/blob/main/build-kmod-rtl8814au.sh) file and [this](https://github.com/morrownr/8821au-20210708) driver.

What are the next steps that I need to take?