### PR TITLE
feat: enable zfs on fsync-ba

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -59,8 +59,6 @@ jobs:
             cfile_suffix: zfs
           - kernel_flavor: fsync
             cfile_suffix: zfs
-          - kernel_flavor: fsync-ba
-            cfile_suffix: zfs
           - kernel_flavor: surface
             cfile_suffix: zfs
 


### PR DESCRIPTION
Use fsync-ba as a fallback if fsync-coreos isn't building due to no matching versions.

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.
