### PR TITLE
chore: Set higher priority to the repo since landing of Negativo 17 m…

### DIFF
--- a/build-ublue-os-akmods-addons.sh
+++ b/build-ublue-os-akmods-addons.sh
@@ -5,7 +5,7 @@ set -oeux pipefail
 
 ### BUILD UBLUE AKMODS-ADDONS RPM
 # ensure a higher priority is set for our ublue akmods COPR to pull deps from it over other sources (99 is default)
-echo "priority=90" >> /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo
+echo "priority=85" >> /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo
 
 install -D /etc/pki/akmods/certs/public_key.der /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/public_key.der
 rpmbuild -ba \


### PR DESCRIPTION
…ultimedia repo as default

Negativo 17 multimedia repo has 90 as priority now, so set this to be lower than it (85).

Avoids this potential issue:
https://github.com/ublue-os/akmods/pull/116