### PR TITLE
fix: update logic to pull signing keys on everything except PRs

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -194,7 +194,7 @@ jobs:
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/1728152?s=200&v=4
 
       - name: Retrieve Signing Key
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group'
+        if: github.event_name != 'pull_request'
         shell: bash
         run: |
           mkdir -p certs


### PR DESCRIPTION
Resolves an issue brought to our attention in Discord by RoyalOughtness ([here](https://discord.com/channels/1072614816579063828/1072617059265032342/1296961344385450046))