### PR TITLE
chore: refactor package rename script to support all kernel versions

### DIFF
--- a/Containerfile.common
+++ b/Containerfile.common
@@ -34,17 +34,17 @@ ADD https://negativo17.org/repos/fedora-multimedia.repo \
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \
     if [[ "${KERNEL_FLAVOR}" =~ "coreos" ]]; then \
-      /tmp/build-ublue-os-ucore-addons.sh && \
-      cp /tmp/ublue-os-ucore-addons/rpmbuild/RPMS/noarch/ublue-os-ucore-addons*.rpm \
-        /var/cache/rpms/ucore/ \
+    /tmp/build-ublue-os-ucore-addons.sh && \
+    cp /tmp/ublue-os-ucore-addons/rpmbuild/RPMS/noarch/ublue-os-ucore-addons*.rpm \
+    /var/cache/rpms/ucore/ \
     ; fi && \
     /tmp/build-ublue-os-akmods-addons.sh && \
     cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm \
-      /var/cache/rpms/ublue-os/ && \
+    /var/cache/rpms/ublue-os/ && \
     if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
-        export KERNEL_NAME="kernel" \
+    export KERNEL_NAME="kernel" \
     ; else \
-        export KERNEL_NAME="kernel-surface" \
+    export KERNEL_NAME="kernel-surface" \
     ; fi && \
     /tmp/build-kmod-kvmfr.sh && \
     /tmp/build-kmod-openrazer.sh && \
@@ -54,22 +54,26 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-kmod-xone.sh && \
     /tmp/dual-sign.sh && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
-        cp "${RPM}" /var/cache/rpms/kmods/; \
+    cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     for RPM in $(find /root/rpmbuild/RPMS/"$(uname -m)"/ -type f -name \*.rpm); do \
-        cp "${RPM}" /var/cache/rpms/kmods/; \
+    cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     find /var/cache/rpms
 
 # Remove kernel version from kmod package names
-# FIXME: This will only work for 6.* kernels unfortunately
 # FIXME: The sed is a gross hack, maybe PR upstream?
 RUN set -e; \
     sed -i -e 's/args = \["rpmbuild", "-bb"\]/args = \["rpmbuild", "-bb", "--buildroot", "#{build_path}\/BUILD"\]/g' /usr/local/share/gems/gems/fpm-*/lib/fpm/package/rpm.rb; \
+    kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=${basename%%-6*}; \
-        fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
+        name=$(echo ${basename} | sed -r "s/(-${kernel_version})//g"); \
+        if [[ "$basename" == *"$kernel_version"* ]]; then \
+            fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
+        else \
+            echo "Skipping $basename as it does not contain $kernel_version in its name"; \
+        fi; \
     done
 
 FROM scratch

--- a/Containerfile.common
+++ b/Containerfile.common
@@ -34,17 +34,17 @@ ADD https://negativo17.org/repos/fedora-multimedia.repo \
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \
     if [[ "${KERNEL_FLAVOR}" =~ "coreos" ]]; then \
-    /tmp/build-ublue-os-ucore-addons.sh && \
-    cp /tmp/ublue-os-ucore-addons/rpmbuild/RPMS/noarch/ublue-os-ucore-addons*.rpm \
-    /var/cache/rpms/ucore/ \
+      /tmp/build-ublue-os-ucore-addons.sh && \
+      cp /tmp/ublue-os-ucore-addons/rpmbuild/RPMS/noarch/ublue-os-ucore-addons*.rpm \
+        /var/cache/rpms/ucore/ \
     ; fi && \
     /tmp/build-ublue-os-akmods-addons.sh && \
     cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm \
-    /var/cache/rpms/ublue-os/ && \
+      /var/cache/rpms/ublue-os/ && \
     if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
-    export KERNEL_NAME="kernel" \
+        export KERNEL_NAME="kernel" \
     ; else \
-    export KERNEL_NAME="kernel-surface" \
+        export KERNEL_NAME="kernel-surface" \
     ; fi && \
     /tmp/build-kmod-kvmfr.sh && \
     /tmp/build-kmod-openrazer.sh && \
@@ -54,10 +54,10 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-kmod-xone.sh && \
     /tmp/dual-sign.sh && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
-    cp "${RPM}" /var/cache/rpms/kmods/; \
+        cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     for RPM in $(find /root/rpmbuild/RPMS/"$(uname -m)"/ -type f -name \*.rpm); do \
-    cp "${RPM}" /var/cache/rpms/kmods/; \
+        cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     find /var/cache/rpms
 

--- a/Containerfile.common
+++ b/Containerfile.common
@@ -68,7 +68,7 @@ RUN set -e; \
     kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=${basename/-${kernel_version}*/}; \
+        name=${basename%%-${kernel_version}*}; \
         if [[ "$basename" == *"$kernel_version"* ]]; then \
             fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
         else \

--- a/Containerfile.common
+++ b/Containerfile.common
@@ -68,11 +68,11 @@ RUN set -e; \
     kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=$(echo ${basename} | sed -r "s/(-${kernel_version})//g"); \
+        name=${basename/-${kernel_version}*/}; \
         if [[ "$basename" == *"$kernel_version"* ]]; then \
             fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
         else \
-            echo "Skipping $basename as it does not contain $kernel_version in its name"; \
+            echo "Skipping $basename rebuild as its name does not contain $kernel_version"; \
         fi; \
     done
 

--- a/Containerfile.extra
+++ b/Containerfile.extra
@@ -33,13 +33,13 @@ ADD https://negativo17.org/repos/fedora-multimedia.repo \
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \
     if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
-        export KERNEL_NAME="kernel" \
+    export KERNEL_NAME="kernel" \
     ; else \
-        export KERNEL_NAME="kernel-surface" \
+    export KERNEL_NAME="kernel-surface" \
     ; fi && \
     if grep -qv "asus" <<< "${KERNEL_FLAVOR}"; then \
-        /tmp/build-kmod-zenergy.sh && \
-        /tmp/build-kmod-evdi.sh \
+    /tmp/build-kmod-zenergy.sh && \
+    /tmp/build-kmod-evdi.sh \
     ; fi && \
     /tmp/build-kmod-ayaneo-platform.sh && \
     /tmp/build-kmod-ayn-platform.sh && \
@@ -54,25 +54,28 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-kmod-VirtualBox.sh && \
     /tmp/dual-sign.sh && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
-        cp "${RPM}" /var/cache/rpms/kmods/; \
+    cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     for RPM in $(find /root/rpmbuild/RPMS/"$(uname -m)"/ -type f -name \*.rpm); do \
-        cp "${RPM}" /var/cache/rpms/kmods/; \
+    cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     find /var/cache/rpms
 
 # Remove kernel version from kmod package names
-# FIXME: This will only work for 6.* kernels unfortunately
 # FIXME: The sed is a gross hack, maybe PR upstream?
 RUN set -e; \
     sed -i -e 's/args = \["rpmbuild", "-bb"\]/args = \["rpmbuild", "-bb", "--buildroot", "#{build_path}\/BUILD"\]/g' /usr/local/share/gems/gems/fpm-*/lib/fpm/package/rpm.rb; \
+    kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=${basename%%-6*}; \
-        fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
+        name=$(echo ${basename} | sed -r "s/(-${kernel_version})//g"); \
+        if [[ "$basename" == *"$kernel_version"* ]]; then \
+            fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
+        else \
+            echo "Skipping $basename as it does not contain $kernel_version in its name"; \
+        fi; \
     done
 
 FROM scratch
 
 COPY --from=builder /var/cache/rpms /rpms
-

--- a/Containerfile.extra
+++ b/Containerfile.extra
@@ -68,7 +68,7 @@ RUN set -e; \
     kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=${basename/-${kernel_version}*/}; \
+        name=${basename%%-${kernel_version}*}; \
         if [[ "$basename" == *"$kernel_version"* ]]; then \
             fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
         else \

--- a/Containerfile.extra
+++ b/Containerfile.extra
@@ -33,13 +33,13 @@ ADD https://negativo17.org/repos/fedora-multimedia.repo \
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \
     if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
-    export KERNEL_NAME="kernel" \
+        export KERNEL_NAME="kernel" \
     ; else \
-    export KERNEL_NAME="kernel-surface" \
+        export KERNEL_NAME="kernel-surface" \
     ; fi && \
     if grep -qv "asus" <<< "${KERNEL_FLAVOR}"; then \
-    /tmp/build-kmod-zenergy.sh && \
-    /tmp/build-kmod-evdi.sh \
+        /tmp/build-kmod-zenergy.sh && \
+        /tmp/build-kmod-evdi.sh \
     ; fi && \
     /tmp/build-kmod-ayaneo-platform.sh && \
     /tmp/build-kmod-ayn-platform.sh && \
@@ -54,10 +54,10 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-kmod-VirtualBox.sh && \
     /tmp/dual-sign.sh && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
-    cp "${RPM}" /var/cache/rpms/kmods/; \
+        cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     for RPM in $(find /root/rpmbuild/RPMS/"$(uname -m)"/ -type f -name \*.rpm); do \
-    cp "${RPM}" /var/cache/rpms/kmods/; \
+        cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     find /var/cache/rpms
 

--- a/Containerfile.extra
+++ b/Containerfile.extra
@@ -68,11 +68,11 @@ RUN set -e; \
     kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=$(echo ${basename} | sed -r "s/(-${kernel_version})//g"); \
+        name=${basename/-${kernel_version}*/}; \
         if [[ "$basename" == *"$kernel_version"* ]]; then \
             fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
         else \
-            echo "Skipping $basename as it does not contain $kernel_version in its name"; \
+            echo "Skipping $basename rebuild as its name does not contain $kernel_version"; \
         fi; \
     done
 

--- a/Containerfile.nvidia
+++ b/Containerfile.nvidia
@@ -36,37 +36,41 @@ COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \
     if [[ "${KERNEL_FLAVOR}" =~ "coreos" ]]; then \
-      /tmp/build-ublue-os-ucore-nvidia.sh && \
-      cp /tmp/ublue-os-ucore-nvidia/rpmbuild/RPMS/noarch/ublue-os-ucore-nvidia*.rpm \
-        /var/cache/rpms/ucore/ \
+    /tmp/build-ublue-os-ucore-nvidia.sh && \
+    cp /tmp/ublue-os-ucore-nvidia/rpmbuild/RPMS/noarch/ublue-os-ucore-nvidia*.rpm \
+    /var/cache/rpms/ucore/ \
     ; fi && \
     /tmp/build-ublue-os-nvidia-addons.sh && \
     cp /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons*.rpm \
-      /var/cache/rpms/ublue-os/ && \
+    /var/cache/rpms/ublue-os/ && \
     if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
-       export KERNEL_NAME="kernel" \
+    export KERNEL_NAME="kernel" \
     ; else \
-       export KERNEL_NAME="kernel-surface" \
+    export KERNEL_NAME="kernel-surface" \
     ; fi && \
     /tmp/build-kmod-nvidia.sh kernel && \
     /tmp/dual-sign.sh && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
-        cp "${RPM}" /var/cache/rpms/kmods/; \
+    cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     for RPM in $(find /root/rpmbuild/RPMS/"$(uname -m)"/ -type f -name \*.rpm); do \
-        cp "${RPM}" /var/cache/rpms/kmods/; \
+    cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     find /var/cache/rpms
 
 # Remove kernel version from kmod package names
-# FIXME: This will only work for 6.* kernels unfortunately
 # FIXME: The sed is a gross hack, maybe PR upstream?
 RUN set -e; \
     sed -i -e 's/args = \["rpmbuild", "-bb"\]/args = \["rpmbuild", "-bb", "--buildroot", "#{build_path}\/BUILD"\]/g' /usr/local/share/gems/gems/fpm-*/lib/fpm/package/rpm.rb; \
+    kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=${basename%%-6*}; \
-        fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
+        name=$(echo ${basename} | sed -r "s/(-${kernel_version})//g"); \
+        if [[ "$basename" == *"$kernel_version"* ]]; then \
+            fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
+        else \
+            echo "Skipping $basename as it does not contain $kernel_version in its name"; \
+        fi; \
     done
 
 FROM scratch

--- a/Containerfile.nvidia
+++ b/Containerfile.nvidia
@@ -65,11 +65,11 @@ RUN set -e; \
     kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=$(echo ${basename} | sed -r "s/(-${kernel_version})//g"); \
+        name=${basename/-${kernel_version}*/}; \
         if [[ "$basename" == *"$kernel_version"* ]]; then \
             fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
         else \
-            echo "Skipping $basename as it does not contain $kernel_version in its name"; \
+            echo "Skipping $basename rebuild as its name does not contain $kernel_version"; \
         fi; \
     done
 

--- a/Containerfile.nvidia
+++ b/Containerfile.nvidia
@@ -65,7 +65,7 @@ RUN set -e; \
     kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=${basename/-${kernel_version}*/}; \
+        name=${basename%%-${kernel_version}*}; \
         if [[ "$basename" == *"$kernel_version"* ]]; then \
             fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
         else \

--- a/Containerfile.nvidia
+++ b/Containerfile.nvidia
@@ -36,25 +36,25 @@ COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \
     if [[ "${KERNEL_FLAVOR}" =~ "coreos" ]]; then \
-    /tmp/build-ublue-os-ucore-nvidia.sh && \
-    cp /tmp/ublue-os-ucore-nvidia/rpmbuild/RPMS/noarch/ublue-os-ucore-nvidia*.rpm \
-    /var/cache/rpms/ucore/ \
+      /tmp/build-ublue-os-ucore-nvidia.sh && \
+      cp /tmp/ublue-os-ucore-nvidia/rpmbuild/RPMS/noarch/ublue-os-ucore-nvidia*.rpm \
+        /var/cache/rpms/ucore/ \
     ; fi && \
     /tmp/build-ublue-os-nvidia-addons.sh && \
     cp /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons*.rpm \
-    /var/cache/rpms/ublue-os/ && \
+      /var/cache/rpms/ublue-os/ && \
     if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
-    export KERNEL_NAME="kernel" \
+       export KERNEL_NAME="kernel" \
     ; else \
-    export KERNEL_NAME="kernel-surface" \
+       export KERNEL_NAME="kernel-surface" \
     ; fi && \
     /tmp/build-kmod-nvidia.sh kernel && \
     /tmp/dual-sign.sh && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
-    cp "${RPM}" /var/cache/rpms/kmods/; \
+        cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     for RPM in $(find /root/rpmbuild/RPMS/"$(uname -m)"/ -type f -name \*.rpm); do \
-    cp "${RPM}" /var/cache/rpms/kmods/; \
+        cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     find /var/cache/rpms
 

--- a/Containerfile.nvidia-open
+++ b/Containerfile.nvidia-open
@@ -65,11 +65,11 @@ RUN set -e; \
     kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=$(echo ${basename} | sed -r "s/(-${kernel_version})//g"); \
+        name=${basename/-${kernel_version}*/}; \
         if [[ "$basename" == *"$kernel_version"* ]]; then \
             fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
         else \
-            echo "Skipping $basename as it does not contain $kernel_version in its name"; \
+            echo "Skipping $basename rebuild as its name does not contain $kernel_version"; \
         fi; \
     done
 

--- a/Containerfile.nvidia-open
+++ b/Containerfile.nvidia-open
@@ -65,7 +65,7 @@ RUN set -e; \
     kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=${basename/-${kernel_version}*/}; \
+        name=${basename%%-${kernel_version}*}; \
         if [[ "$basename" == *"$kernel_version"* ]]; then \
             fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
         else \

--- a/Containerfile.nvidia-open
+++ b/Containerfile.nvidia-open
@@ -36,37 +36,41 @@ COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \
     if [[ "${KERNEL_FLAVOR}" =~ "coreos" ]]; then \
-      /tmp/build-ublue-os-ucore-nvidia.sh && \
-      cp /tmp/ublue-os-ucore-nvidia/rpmbuild/RPMS/noarch/ublue-os-ucore-nvidia*.rpm \
-        /var/cache/rpms/ucore/ \
+    /tmp/build-ublue-os-ucore-nvidia.sh && \
+    cp /tmp/ublue-os-ucore-nvidia/rpmbuild/RPMS/noarch/ublue-os-ucore-nvidia*.rpm \
+    /var/cache/rpms/ucore/ \
     ; fi && \
     /tmp/build-ublue-os-nvidia-addons.sh && \
     cp /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons*.rpm \
-      /var/cache/rpms/ublue-os/ && \
+    /var/cache/rpms/ublue-os/ && \
     if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
-       export KERNEL_NAME="kernel" \
+    export KERNEL_NAME="kernel" \
     ; else \
-       export KERNEL_NAME="kernel-surface" \
+    export KERNEL_NAME="kernel-surface" \
     ; fi && \
     /tmp/build-kmod-nvidia.sh kernel-open && \
     /tmp/dual-sign.sh && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
-        cp "${RPM}" /var/cache/rpms/kmods/; \
+    cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     for RPM in $(find /root/rpmbuild/RPMS/"$(uname -m)"/ -type f -name \*.rpm); do \
-        cp "${RPM}" /var/cache/rpms/kmods/; \
+    cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     find /var/cache/rpms
 
 # Remove kernel version from kmod package names
-# FIXME: This will only work for 6.* kernels unfortunately
 # FIXME: The sed is a gross hack, maybe PR upstream?
 RUN set -e; \
     sed -i -e 's/args = \["rpmbuild", "-bb"\]/args = \["rpmbuild", "-bb", "--buildroot", "#{build_path}\/BUILD"\]/g' /usr/local/share/gems/gems/fpm-*/lib/fpm/package/rpm.rb; \
+    kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=${basename%%-6*}; \
-        fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
+        name=$(echo ${basename} | sed -r "s/(-${kernel_version})//g"); \
+        if [[ "$basename" == *"$kernel_version"* ]]; then \
+            fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
+        else \
+            echo "Skipping $basename as it does not contain $kernel_version in its name"; \
+        fi; \
     done
 
 FROM scratch

--- a/Containerfile.nvidia-open
+++ b/Containerfile.nvidia-open
@@ -36,25 +36,25 @@ COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \
     if [[ "${KERNEL_FLAVOR}" =~ "coreos" ]]; then \
-    /tmp/build-ublue-os-ucore-nvidia.sh && \
-    cp /tmp/ublue-os-ucore-nvidia/rpmbuild/RPMS/noarch/ublue-os-ucore-nvidia*.rpm \
-    /var/cache/rpms/ucore/ \
+      /tmp/build-ublue-os-ucore-nvidia.sh && \
+      cp /tmp/ublue-os-ucore-nvidia/rpmbuild/RPMS/noarch/ublue-os-ucore-nvidia*.rpm \
+        /var/cache/rpms/ucore/ \
     ; fi && \
     /tmp/build-ublue-os-nvidia-addons.sh && \
     cp /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons*.rpm \
-    /var/cache/rpms/ublue-os/ && \
+      /var/cache/rpms/ublue-os/ && \
     if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
-    export KERNEL_NAME="kernel" \
+       export KERNEL_NAME="kernel" \
     ; else \
-    export KERNEL_NAME="kernel-surface" \
+       export KERNEL_NAME="kernel-surface" \
     ; fi && \
     /tmp/build-kmod-nvidia.sh kernel-open && \
     /tmp/dual-sign.sh && \
     for RPM in $(find /var/cache/akmods/ -type f -name \*.rpm); do \
-    cp "${RPM}" /var/cache/rpms/kmods/; \
+        cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     for RPM in $(find /root/rpmbuild/RPMS/"$(uname -m)"/ -type f -name \*.rpm); do \
-    cp "${RPM}" /var/cache/rpms/kmods/; \
+        cp "${RPM}" /var/cache/rpms/kmods/; \
     done && \
     find /var/cache/rpms
 

--- a/Containerfile.zfs
+++ b/Containerfile.zfs
@@ -28,22 +28,26 @@ COPY --from=kernel_cache /tmp/rpms /tmp/kernel_cache
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \
     if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
-        export KERNEL_NAME="kernel" \
+    export KERNEL_NAME="kernel" \
     ; else \
-        export KERNEL_NAME="kernel-surface" \
+    export KERNEL_NAME="kernel-surface" \
     ; fi && \
     /tmp/build-kmod-zfs.sh && \
     /tmp/dual-sign-zfs.sh
 
 # Remove kernel version from kmod package names
-# FIXME: This will only work for 6.* kernels unfortunately
 # FIXME: The sed is a gross hack, maybe PR upstream?
 RUN set -e; \
     sed -i -e 's/args = \["rpmbuild", "-bb"\]/args = \["rpmbuild", "-bb", "--buildroot", "#{build_path}\/BUILD"\]/g' /usr/local/share/gems/gems/fpm-*/lib/fpm/package/rpm.rb; \
+    kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=${basename%%-6*}; \
-        fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
+        name=$(echo ${basename} | sed -r "s/(-${kernel_version})//g"); \
+        if [[ "$basename" == *"$kernel_version"* ]]; then \
+            fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
+        else \
+            echo "Skipping $basename as it does not contain $kernel_version in its name"; \
+        fi; \
     done
 
 FROM scratch

--- a/Containerfile.zfs
+++ b/Containerfile.zfs
@@ -42,11 +42,11 @@ RUN set -e; \
     kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=$(echo ${basename} | sed -r "s/(-${kernel_version})//g"); \
+        name=${basename/-${kernel_version}*/}; \
         if [[ "$basename" == *"$kernel_version"* ]]; then \
             fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
         else \
-            echo "Skipping $basename as it does not contain $kernel_version in its name"; \
+            echo "Skipping $basename rebuild as its name does not contain $kernel_version"; \
         fi; \
     done
 

--- a/Containerfile.zfs
+++ b/Containerfile.zfs
@@ -28,9 +28,9 @@ COPY --from=kernel_cache /tmp/rpms /tmp/kernel_cache
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \
     if grep -qv "surface" <<< "${KERNEL_FLAVOR}"; then \
-    export KERNEL_NAME="kernel" \
+        export KERNEL_NAME="kernel" \
     ; else \
-    export KERNEL_NAME="kernel-surface" \
+        export KERNEL_NAME="kernel-surface" \
     ; fi && \
     /tmp/build-kmod-zfs.sh && \
     /tmp/dual-sign-zfs.sh

--- a/Containerfile.zfs
+++ b/Containerfile.zfs
@@ -42,7 +42,7 @@ RUN set -e; \
     kernel_version=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core | head -n 1); \
     for rpm in $(find /var/cache/rpms/kmods -type f -name \*.rpm); do \
         basename=$(basename ${rpm}); \
-        name=${basename/-${kernel_version}*/}; \
+        name=${basename%%-${kernel_version}*}; \
         if [[ "$basename" == *"$kernel_version"* ]]; then \
             fpm --verbose -s rpm -t rpm -p ${rpm} -f --name ${name} ${rpm}; \
         else \


### PR DESCRIPTION
Updates the RPM renaming script to read the kernel version from the installed kernel-core RPM, removing that string from the package names if it exists.