### PR TITLE
feat: add udev rules for nvidia extra device PM

### DIFF
--- a/Containerfile.nvidia
+++ b/Containerfile.nvidia
@@ -31,7 +31,7 @@ COPY files/usr/lib/systemd/system/ublue-nvctk-cdi.service /tmp/ublue-os-nvidia-a
 COPY files/usr/lib/systemd/system/ublue-nvctk-cdi.service /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/ublue-nvctk-cdi.service
 COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/70-ublue-nvctk-cdi.preset
 COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/70-ublue-nvctk-cdi.preset
-
+COPY files/etc/udev/rules.d/60-nvidia-extra-devices-pm.rules /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/60-nvidia-extra-devices-pm.rules
 
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \

--- a/Containerfile.nvidia-open
+++ b/Containerfile.nvidia-open
@@ -31,7 +31,7 @@ COPY files/usr/lib/systemd/system/ublue-nvctk-cdi.service /tmp/ublue-os-nvidia-a
 COPY files/usr/lib/systemd/system/ublue-nvctk-cdi.service /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/ublue-nvctk-cdi.service
 COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/70-ublue-nvctk-cdi.preset
 COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/70-ublue-nvctk-cdi.preset
-
+COPY files/etc/udev/rules.d/60-nvidia-extra-devices-pm.rules /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/60-nvidia-extra-devices-pm.rules
 
 RUN --mount=type=cache,dst=/var/cache/dnf \
     /tmp/build-prep.sh && \

--- a/files/etc/udev/rules.d/60-nvidia-extra-devices-pm.rules
+++ b/files/etc/udev/rules.d/60-nvidia-extra-devices-pm.rules
@@ -1,0 +1,8 @@
+# Remove NVIDIA USB xHCI Host Controller devices, if present
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c0330", ATTR{remove}="1"
+
+# Remove NVIDIA USB Type-C UCSI devices, if present
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c8000", ATTR{remove}="1"
+
+# Remove NVIDIA Audio devices, if present
+ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", ATTR{remove}="1"

--- a/ublue-os-nvidia-addons.spec
+++ b/ublue-os-nvidia-addons.spec
@@ -16,6 +16,7 @@ Source3:        70-ublue-nvctk-cdi.preset
 Source4:        environment
 Source5:        negativo17-fedora-nvidia.repo
 Source6:        eyecantcu-supergfxctl.repo
+Source7:        60-nvidia-extra-devices-pm.rules
 
 %description
 Adds various runtime files for nvidia support.


### PR DESCRIPTION
This is a nice-to-have so that any extra USB/Audio devices on nvidia cards are also able to take advantage of powermanagement.

Closes: ublue-os/hwe#291

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
