### PR TITLE
feat: enable coreos-stable for F41

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -43,7 +43,7 @@ jobs:
           - nvidia-open
           - zfs
         exclude:
-          - fedora_version: 41
+          - fedora_version: 39
             kernel_flavor: coreos-stable
           - fedora_version: 40
             kernel_flavor: coreos-testing


### PR DESCRIPTION
Don't merge until coreos-stable is on F41 and kernel cache is merged.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
