### PR TITLE
fix: change inputs to rpmrebuild

### DIFF
--- a/dual-sign-zfs.sh
+++ b/dual-sign-zfs.sh
@@ -32,10 +32,9 @@ if [[ "${DUAL_SIGN}" == "true" ]]; then
             /tmp/dual-sign-check.sh "${KERNEL}" "${module}" "${PUBLIC_CHAIN}"
         fi
     done
-
     find /var/cache/rpms/kmods/zfs -type f -name "\kmod-*.rpm" | grep -v debug | grep -v devel
     RPMPATH=$(find /var/cache/rpms/kmods/zfs -type f -name "\kmod-*.rpm" | grep -v debug | grep -v devel)
-    RPM=$(basename $( echo ${RPMPATH} | sed 's/\.rpm//' ))
+    RPM=$(basename $(${RPMPATH})
     rpmrebuild --additional=--buildroot=/tmp/buildroot --batch ${RPM}
     rm -rf /usr/lib/modules/"${KERNEL}"/extra
     dnf reinstall -y /root/rpmbuild/RPMS/"$(uname -m)"/kmod-*-"${KERNEL}"-*.rpm

--- a/dual-sign-zfs.sh
+++ b/dual-sign-zfs.sh
@@ -32,7 +32,11 @@ if [[ "${DUAL_SIGN}" == "true" ]]; then
             /tmp/dual-sign-check.sh "${KERNEL}" "${module}" "${PUBLIC_CHAIN}"
         fi
     done
-    rpmrebuild --additional=--buildroot=/tmp/buildroot --batch /var/cache/rpms/kmods/zfs/kmod-zfs-*.rpm
+
+    find /var/cache/rpms/kmods/zfs -type f -name "\kmod-*.rpm" | grep -v debug | grep -v devel
+    RPMPATH=$(find /var/cache/rpms/kmods/zfs -type f -name "\kmod-*.rpm" | grep -v debug | grep -v devel)
+    RPM=$(basename $( echo ${RPMPATH} | sed 's/\.rpm//' ))
+    rpmrebuild --additional=--buildroot=/tmp/buildroot --batch ${RPM}
     rm -rf /usr/lib/modules/"${KERNEL}"/extra
     dnf reinstall -y /root/rpmbuild/RPMS/"$(uname -m)"/kmod-*-"${KERNEL}"-*.rpm
     for module in /usr/lib/modules/"${KERNEL}"/extra/*/*.ko*; do

--- a/dual-sign-zfs.sh
+++ b/dual-sign-zfs.sh
@@ -34,8 +34,8 @@ if [[ "${DUAL_SIGN}" == "true" ]]; then
     done
     find /var/cache/rpms/kmods/zfs -type f -name "\kmod-*.rpm" | grep -v debug | grep -v devel
     RPMPATH=$(find /var/cache/rpms/kmods/zfs -type f -name "\kmod-*.rpm" | grep -v debug | grep -v devel)
-    RPM=$(basename $(${RPMPATH})
-    rpmrebuild --additional=--buildroot=/tmp/buildroot --batch ${RPM}
+    RPM=$(basename "${RPMPATH}")
+    rpmrebuild --additional=--buildroot=/tmp/buildroot --batch "${RPM}"
     rm -rf /usr/lib/modules/"${KERNEL}"/extra
     dnf reinstall -y /root/rpmbuild/RPMS/"$(uname -m)"/kmod-*-"${KERNEL}"-*.rpm
     for module in /usr/lib/modules/"${KERNEL}"/extra/*/*.ko*; do

--- a/dual-sign-zfs.sh
+++ b/dual-sign-zfs.sh
@@ -34,7 +34,7 @@ if [[ "${DUAL_SIGN}" == "true" ]]; then
     done
     find /var/cache/rpms/kmods/zfs -type f -name "\kmod-*.rpm" | grep -v debug | grep -v devel
     RPMPATH=$(find /var/cache/rpms/kmods/zfs -type f -name "\kmod-*.rpm" | grep -v debug | grep -v devel)
-    RPM=$(basename "${RPMPATH}")
+    RPM=$(basename $(echo "${RPMPATH}" | sed 's/\.rpm//'))
     rpmrebuild --additional=--buildroot=/tmp/buildroot --batch "${RPM}"
     rm -rf /usr/lib/modules/"${KERNEL}"/extra
     dnf reinstall -y /root/rpmbuild/RPMS/"$(uname -m)"/kmod-*-"${KERNEL}"-*.rpm

--- a/dual-sign.sh
+++ b/dual-sign.sh
@@ -29,12 +29,9 @@ if [[ "${DUAL_SIGN}" == "true" ]]; then
             /tmp/dual-sign-check.sh "${KERNEL}" "${module}" "${PUBLIC_CHAIN}"
         fi
     done
-
-    rpm -qa |grep kmod
-
     find /var/cache/akmods -type f -name "\kmod-*.rpm"
     for RPMPATH in $(find /var/cache/akmods/ -type f -name \kmod-*.rpm); do
-        RPM=$(basename $( echo ${RPMPATH} | sed 's/\.rpm//' ))
+        RPM=$(basename ${RPMPATH})
         mkdir -p /tmp/buildroot
         cp -r /{usr,lib} /tmp/buildroot
         rpmrebuild --additional=--buildroot=/tmp/buildroot --batch "$RPM"

--- a/dual-sign.sh
+++ b/dual-sign.sh
@@ -31,7 +31,7 @@ if [[ "${DUAL_SIGN}" == "true" ]]; then
     done
     find /var/cache/akmods -type f -name "\kmod-*.rpm"
     for RPMPATH in $(find /var/cache/akmods/ -type f -name \kmod-*.rpm); do
-        RPM=$(basename ${RPMPATH})
+        RPM=$(basename "${RPMPATH}")
         mkdir -p /tmp/buildroot
         cp -r /{usr,lib} /tmp/buildroot
         rpmrebuild --additional=--buildroot=/tmp/buildroot --batch "$RPM"

--- a/dual-sign.sh
+++ b/dual-sign.sh
@@ -31,7 +31,7 @@ if [[ "${DUAL_SIGN}" == "true" ]]; then
     done
     find /var/cache/akmods -type f -name "\kmod-*.rpm"
     for RPMPATH in $(find /var/cache/akmods/ -type f -name \kmod-*.rpm); do
-        RPM=$(basename "${RPMPATH}")
+        RPM=$(basename $(echo "${RPMPATH}" | sed 's/\.rpm//'))
         mkdir -p /tmp/buildroot
         cp -r /{usr,lib} /tmp/buildroot
         rpmrebuild --additional=--buildroot=/tmp/buildroot --batch "$RPM"

--- a/dual-sign.sh
+++ b/dual-sign.sh
@@ -29,8 +29,12 @@ if [[ "${DUAL_SIGN}" == "true" ]]; then
             /tmp/dual-sign-check.sh "${KERNEL}" "${module}" "${PUBLIC_CHAIN}"
         fi
     done
+
+    rpm -qa |grep kmod
+
     find /var/cache/akmods -type f -name "\kmod-*.rpm"
-    for RPM in $(find /var/cache/akmods/ -type f -name \kmod-*.rpm); do
+    for RPMPATH in $(find /var/cache/akmods/ -type f -name \kmod-*.rpm); do
+        RPM=$(basename $( echo ${RPMPATH} | sed 's/\.rpm//' ))
         mkdir -p /tmp/buildroot
         cp -r /{usr,lib} /tmp/buildroot
         rpmrebuild --additional=--buildroot=/tmp/buildroot --batch "$RPM"


### PR DESCRIPTION
rpmrebuild updated from 2.17 to 2.20 in Fedora repos, changing the function function which checks if a package is installed.

This fixes the inputs to that command.
