### PR TITLE
Fixes typo in the log path for Framewok laptop kmod build

### DIFF
--- a/build_files/common/build-kmod-framework-laptop.sh
+++ b/build_files/common/build-kmod-framework-laptop.sh
@@ -13,6 +13,6 @@ dnf install -y \
     akmod-framework-laptop-*.fc${RELEASE}.${ARCH}
 akmods --force --kernels "${KERNEL}" --kmod framework-laptop
 modinfo /usr/lib/modules/${KERNEL}/extra/framework-laptop/framework_laptop.ko.xz > /dev/null \
-|| (find /var/cache/akmods/framework_laptop/ -name \*.log -print -exec cat {} \; && exit 1)
+|| (find /var/cache/akmods/framework-laptop/ -name \*.log -print -exec cat {} \; && exit 1)
 
 rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo


### PR DESCRIPTION
This is just a minor fix to the log path for kmod build step for framework laptop. This part of the code only gets triggered in case of kmod build failure, hence it has not been caught yet. 
Without this fix, if the kmod build step fails you would not see the build log to be able to debug the issue because the the `find` command will fail with file not found 
