### PR TITLE
feat(bazzite): add webhook for bazzite kernel and update url

### DIFF
--- a/.github/actions/get-kernel-version/action.yml
+++ b/.github/actions/get-kernel-version/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: "The Kernel flavor: main, bazzite, coreos-stable, etc"
     required: true
     type: string
+  bazzite_tag:
+    description: "Optional (bazzite kernel) tag to use instead of latest"
+    required: false
+    type: string
 outputs:
   kernel_build_tag:
     description: "Optional (bazzite specific) tag"
@@ -99,7 +103,11 @@ runs:
             linux=$($dnf repoquery --repoid copr:copr.fedorainfracloud.org:sentry:kernel-ba --whatprovides kernel | sort -V | tail -n1 | sed 's/.*://')
             ;;
           "bazzite")
-            latest="$(curl "https://api.github.com/repos/hhd-dev/kernel-bazzite/releases/latest" )"
+            if [[ -n "${{ inputs.bazzite_tag }}" ]]; then
+              latest="$(curl "https://api.github.com/repos/bazzite-org/kernel-bazzite/releases/tags/${{ inputs.bazzite_tag }}" )"
+            else
+              latest="$(curl "https://api.github.com/repos/bazzite-org/kernel-bazzite/releases/latest" )"
+            fi
             linux=$(echo -E "$latest" | jq -r '.assets[].name' | grep -E 'kernel-.*.rpm' | grep "fc${{ inputs.fedora_version }}.x86_64" | head -1 | sed "s/kernel-//g" | sed "s/.rpm//g" )
             build_tag=$(echo -E $latest | jq -r '.tag_name')
             ;;

--- a/.github/workflows/build-bazzite.yml
+++ b/.github/workflows/build-bazzite.yml
@@ -1,0 +1,20 @@
+name: bazzite akmods
+on:
+  repository_dispatch:
+    types: [bazzite-kernel-build]
+
+jobs:
+  kernel-akmods:
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        fedora_version:
+          - 41
+        kernel_flavor:
+          - bazzite
+    with:
+      fedora_version: ${{ matrix.fedora_version }}
+      kernel_flavor: ${{ matrix.kernel_flavor }}
+      bazzite_tag: ${{ github.event.client_payload.release_tag }}

--- a/.github/workflows/build-bazzite.yml
+++ b/.github/workflows/build-bazzite.yml
@@ -2,6 +2,12 @@ name: bazzite akmods
 on:
   repository_dispatch:
     types: [bazzite-kernel-build]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag (leave empty for latest)'
+        required: false
+        default: ''
 
 jobs:
   kernel-akmods:
@@ -17,4 +23,4 @@ jobs:
     with:
       fedora_version: ${{ matrix.fedora_version }}
       kernel_flavor: ${{ matrix.kernel_flavor }}
-      bazzite_tag: ${{ github.event.client_payload.release_tag }}
+      bazzite_tag: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.release_tag || github.event.inputs.release_tag }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -10,6 +10,10 @@ on:
         description: "The Kernel flavor: main, bazzite, coreos-stable, etc"
         required: true
         type: string
+      bazzite_tag:
+        description: "The release tag for the bazzite kernel"
+        required: false
+        type: string
 env:
   IMAGE_BASE_NAME: akmods
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
@@ -43,6 +47,7 @@ jobs:
         with:
           fedora_version: ${{ inputs.fedora_version }}
           kernel_flavor: ${{ inputs.kernel_flavor }}
+          bazzite_tag: ${{ inputs.bazzite_tag }}
 
       - name: Cache Kernel RPMs
         id: cache-kernel

--- a/fetch-kernel.sh
+++ b/fetch-kernel.sh
@@ -60,15 +60,15 @@ elif [[ "${kernel_flavor}" == "surface" ]]; then
         libwacom-surface-data
 elif [[ "${kernel_flavor}" == "bazzite" ]]; then
     # Using curl for bazzite release
-    curl -#fLO https://github.com/hhd-dev/kernel-bazzite/releases/download/"$build_tag"/kernel-"$kernel_version".rpm
-    curl -#fLO https://github.com/hhd-dev/kernel-bazzite/releases/download/"$build_tag"/kernel-core-"$kernel_version".rpm
-    curl -#fLO https://github.com/hhd-dev/kernel-bazzite/releases/download/"$build_tag"/kernel-modules-"$kernel_version".rpm
-    curl -#fLO https://github.com/hhd-dev/kernel-bazzite/releases/download/"$build_tag"/kernel-modules-core-"$kernel_version".rpm
-    curl -#fLO https://github.com/hhd-dev/kernel-bazzite/releases/download/"$build_tag"/kernel-modules-extra-"$kernel_version".rpm
-    curl -#fLO https://github.com/hhd-dev/kernel-bazzite/releases/download/"$build_tag"/kernel-devel-"$kernel_version".rpm
-    curl -#fLO https://github.com/hhd-dev/kernel-bazzite/releases/download/"$build_tag"/kernel-devel-matched-"$kernel_version".rpm
-    curl -#fLO https://github.com/hhd-dev/kernel-bazzite/releases/download/"$build_tag"/kernel-uki-virt-"$kernel_version".rpm
-    # curl -LO https://github.com/hhd-dev/kernel-bazzite/releases/download/"$build_tag"/kernel-uki-virt-addons-"$kernel_version".rpm
+    curl -#fLO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-"$kernel_version".rpm
+    curl -#fLO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-core-"$kernel_version".rpm
+    curl -#fLO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-modules-"$kernel_version".rpm
+    curl -#fLO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-modules-core-"$kernel_version".rpm
+    curl -#fLO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-modules-extra-"$kernel_version".rpm
+    curl -#fLO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-devel-"$kernel_version".rpm
+    curl -#fLO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-devel-matched-"$kernel_version".rpm
+    curl -#fLO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-uki-virt-"$kernel_version".rpm
+    # curl -LO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-uki-virt-addons-"$kernel_version".rpm
 else
     KERNEL_MAJOR_MINOR_PATCH=$(echo "$kernel_version" | cut -d '-' -f 1)
     KERNEL_RELEASE="$(echo "$kernel_version" | cut -d - -f 2 | cut -d . -f 1).$(echo "$kernel_version" | cut -d - -f 2 | cut -d . -f 2)"


### PR DESCRIPTION
Alternative to https://github.com/ublue-os/akmods/pull/309 since I cannot write to it.

Allows for building akmods for prerelease kernels instead of always using the latest tag. Also updates the kernel url and allows for running workflow_dispatch