### PR TITLE
chore: enable Bazzite and CoreOS kernels

### DIFF
--- a/.github/workflows/build-42.yml
+++ b/.github/workflows/build-42.yml
@@ -20,7 +20,6 @@ jobs:
         fedora_version:
           - 42
         kernel_flavor:
-          - bazzite
           - main
           - coreos-stable
           - coreos-testing

--- a/.github/workflows/build-42.yml
+++ b/.github/workflows/build-42.yml
@@ -20,7 +20,10 @@ jobs:
         fedora_version:
           - 42
         kernel_flavor:
+          - bazzite
           - main
+          - coreos-stable
+          - coreos-testing
     with:
       fedora_version: ${{ matrix.fedora_version }}
       kernel_flavor: ${{ matrix.kernel_flavor }}

--- a/.github/workflows/build-bazzite.yml
+++ b/.github/workflows/build-bazzite.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         fedora_version:
           - 41
+          - 42
         kernel_flavor:
           - bazzite
     with:


### PR DESCRIPTION
Enables the builds for Bazzite and CoreOS kernels in F42 since they were disabled due to failing builds