### PR TITLE
fix: specify crc32 integrity check when recompressing kmods

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -349,6 +349,7 @@ jobs:
             BUILDER_IMAGE=${{ env.BUILDER_IMAGE }}
             KERNEL_FLAVOR=${{ inputs.kernel_flavor }}
             FEDORA_MAJOR_VERSION=${{ inputs.fedora_version }}
+            RPMFUSION_MIRROR=${{ vars.RPMFUSION_MIRROR }}
             INPUT_AKMODS=${{ env.IMAGE_NAME }}
             INPUT_TAG=${{ env.default_tag }}
             DUAL_SIGN=true

--- a/Containerfile.zfs
+++ b/Containerfile.zfs
@@ -1,5 +1,5 @@
 ###
-### Containerfile.zfs - used to build ONLY ZFS kmod
+### Containerfile.zfs - used to build ONLY ZFS kmod and utilities
 ###
 
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-42}"

--- a/Containerfile.zfs
+++ b/Containerfile.zfs
@@ -1,5 +1,5 @@
 ###
-### Containerfile.zfs - used to build ONLY ZFS kmod and utilities
+### Containerfile.zfs - used to build ONLY ZFS kmod
 ###
 
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-42}"

--- a/build_files/shared/build-prep.sh
+++ b/build_files/shared/build-prep.sh
@@ -28,8 +28,8 @@ dnf install -y \
     "${RPMFUSION_MIRROR_RPMS}"/nonfree/fedora/rpmfusion-nonfree-release-"${RELEASE}".noarch.rpm \
     fedora-repos-archive
 
-# after F41 launches, bump to 42
-if [[ "${FEDORA_MAJOR_VERSION}" -ge 41 ]]; then
+# after F42 launches, bump to 43
+if [[ "${FEDORA_MAJOR_VERSION}" -ge 42 ]]; then
     # pre-release rpmfusion is in a different location
     sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
     # pre-release rpmfusion needs to enable testing

--- a/build_files/shared/check-signatures.sh
+++ b/build_files/shared/check-signatures.sh
@@ -12,7 +12,7 @@ do
     if [[ "$module_suffix" == ".xz" ]]; then
             xz --decompress "$module"
             /tmp/dual-sign-check.sh "${KERNEL}" "${module_basename}" "${PUBLIC_CHAIN}"
-            xz -f "${module_basename}"
+            xz -C crc32 -f "${module_basename}"
     elif [[ "$module_suffix" == ".gz" ]]; then
             gzip -d "$module"
             /tmp/dual-sign-check.sh "${KERNEL}" "${module_basename}" "${PUBLIC_CHAIN}"

--- a/build_files/shared/dual-sign.sh
+++ b/build_files/shared/dual-sign.sh
@@ -16,7 +16,7 @@ if [[ "${DUAL_SIGN}" == "true" ]]; then
             openssl cms -sign -signer "${SIGNING_KEY_1}" -signer "${SIGNING_KEY_2}" -binary -in "$module_basename" -outform DER -out "${module_basename}.cms" -nocerts -noattr -nosmimecap
             /usr/src/kernels/"${KERNEL}"/scripts/sign-file -s "${module_basename}.cms" sha256 "${PUBLIC_CHAIN}" "${module_basename}"
             /tmp/dual-sign-check.sh "${KERNEL}" "${module_basename}" "${PUBLIC_CHAIN}"
-            xz -f "${module_basename}"
+            xz -C crc32 -f "${module_basename}"
         elif [[ "$module_suffix" == ".gz" ]]; then
             gzip -d "$module"
             openssl cms -sign -signer "${SIGNING_KEY_1}" -signer "${SIGNING_KEY_2}" -binary -in "$module_basename" -outform DER -out "${module_basename}.cms" -nocerts -noattr -nosmimecap

--- a/build_files/shared/test-prep.sh
+++ b/build_files/shared/test-prep.sh
@@ -33,7 +33,7 @@ if [ -n "${RPMFUSION_MIRROR}" ]; then
     RPMFUSION_MIRROR_RPMS=${RPMFUSION_MIRROR}
 fi
 
-if [[ "${RELEASE}" -ge 41 ]]; then
+if [[ "${RELEASE}" -ge 42 ]]; then
     COPR_RELEASE="rawhide"
 else
     COPR_RELEASE="${RELEASE}"
@@ -91,8 +91,8 @@ dnf install -y \
     openssl
 
 
-# after F41 launches, bump to 42
-if [[ "${FEDORA_MAJOR_VERSION}" -ge 41 ]]; then
+# after F42 launches, bump to 43
+if [[ "${FEDORA_MAJOR_VERSION}" -ge 42 ]]; then
     # pre-release rpmfusion is in a different location
     sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
     # pre-release rpmfusion needs to enable testing

--- a/build_files/shared/test-prep.sh
+++ b/build_files/shared/test-prep.sh
@@ -52,6 +52,7 @@ if [ -n "${RPMFUSION_MIRROR}" ]; then
     sed -i "s%^#baseurl=http://download1.rpmfusion.org%baseurl=${RPMFUSION_MIRROR}%" /etc/yum.repos.d/rpmfusion-*.repo
 fi
 
+# after F42 launches, bump to 43
 if [[ "${RELEASE}" -ge 42 ]]; then
     COPR_RELEASE="rawhide"
 else

--- a/build_files/shared/test-prep.sh
+++ b/build_files/shared/test-prep.sh
@@ -32,6 +32,25 @@ RPMFUSION_MIRROR_RPMS="https://mirrors.rpmfusion.org"
 if [ -n "${RPMFUSION_MIRROR}" ]; then
     RPMFUSION_MIRROR_RPMS=${RPMFUSION_MIRROR}
 fi
+dnf install -y \
+    "${RPMFUSION_MIRROR_RPMS}"/free/fedora/rpmfusion-free-release-"${RELEASE}".noarch.rpm \
+    "${RPMFUSION_MIRROR_RPMS}"/nonfree/fedora/rpmfusion-nonfree-release-"${RELEASE}".noarch.rpm \
+    fedora-repos-archive
+
+# after F42 launches, bump to 43
+if [[ "${FEDORA_MAJOR_VERSION}" -ge 42 ]]; then
+    # pre-release rpmfusion is in a different location
+    sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
+    # pre-release rpmfusion needs to enable testing
+    sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/rpmfusion-*-updates-testing.repo
+fi
+
+if [ -n "${RPMFUSION_MIRROR}" ]; then
+    # force use of single rpmfusion mirror
+    echo "Using single rpmfusion mirror: ${RPMFUSION_MIRROR}"
+    sed -i.bak "s%^metalink=%#metalink=%" /etc/yum.repos.d/rpmfusion-*.repo
+    sed -i "s%^#baseurl=http://download1.rpmfusion.org%baseurl=${RPMFUSION_MIRROR}%" /etc/yum.repos.d/rpmfusion-*.repo
+fi
 
 if [[ "${RELEASE}" -ge 42 ]]; then
     COPR_RELEASE="rawhide"
@@ -85,26 +104,7 @@ if [[ -f $(find /tmp/akmods-rpms/kmods/kmod-nvidia-*.rpm) ]]; then
 fi
 
 dnf install -y \
-    "${RPMFUSION_MIRROR_RPMS}"/free/fedora/rpmfusion-free-release-"${RELEASE}".noarch.rpm \
-    "${RPMFUSION_MIRROR_RPMS}"/nonfree/fedora/rpmfusion-nonfree-release-"${RELEASE}".noarch.rpm \
-    fedora-repos-archive \
     openssl
-
-
-# after F42 launches, bump to 43
-if [[ "${FEDORA_MAJOR_VERSION}" -ge 42 ]]; then
-    # pre-release rpmfusion is in a different location
-    sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
-    # pre-release rpmfusion needs to enable testing
-    sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/rpmfusion-*-updates-testing.repo
-fi
-
-if [ -n "${RPMFUSION_MIRROR}" ]; then
-    # force use of single rpmfusion mirror
-    echo "Using single rpmfusion mirror: ${RPMFUSION_MIRROR}"
-    sed -i.bak "s%^metalink=%#metalink=%" /etc/yum.repos.d/rpmfusion-*.repo
-    sed -i "s%^#baseurl=http://download1.rpmfusion.org%baseurl=${RPMFUSION_MIRROR}%" /etc/yum.repos.d/rpmfusion-*.repo
-fi
 
 if [[ ! -s "/tmp/certs/private_key.priv" ]]; then
     echo "WARNING: Using test signing key. Run './generate-akmods-key' for production builds."

--- a/build_files/zfs/dual-sign-zfs.sh
+++ b/build_files/zfs/dual-sign-zfs.sh
@@ -19,7 +19,7 @@ if [[ "${DUAL_SIGN}" == "true" ]]; then
             openssl cms -sign -signer "${SIGNING_KEY_1}" -signer "${SIGNING_KEY_2}" -binary -in "$module_basename" -outform DER -out "${module_basename}.cms" -nocerts -noattr -nosmimecap
             /usr/src/kernels/"${KERNEL}"/scripts/sign-file -s "${module_basename}.cms" sha256 "${PUBLIC_CHAIN}" "${module_basename}"
             /tmp/dual-sign-check.sh "${KERNEL}" "${module_basename}" "${PUBLIC_CHAIN}"
-            xz -f "${module_basename}"
+            xz -C crc32 -f "${module_basename}"
         elif [[ "$module_suffix" == ".gz" ]]; then
             gzip -d "$module"
             openssl cms -sign -signer "${SIGNING_KEY_1}" -signer "${SIGNING_KEY_2}" -binary -in "$module_basename" -outform DER -out "${module_basename}.cms" -nocerts -noattr -nosmimecap


### PR DESCRIPTION
Newer kernels in F42 now require this integrity check for xz compressed kmods. The lack of it was causing failure loading our recompressed kmods on F42.

In addition to the core fix, this includes some tweaks to ensure that rpmfusion works as expected for build/test with/without a single mirror defined, and to support F42 still being "development" in rpmfusion repositories.  

Fixes: #318

See issue for more context. 

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
