### PR TITLE
feat: disable v4l2loopback kmod for Fedora 42+

### DIFF
--- a/build_files/common/build-kmod-v4l2loopback.sh
+++ b/build_files/common/build-kmod-v4l2loopback.sh
@@ -2,14 +2,19 @@
 
 set -oeux pipefail
 
+# TODO: completely remove this script once F41 no longer is built for ublue
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
-### BUILD v4l2loopbak (succeed or fail-fast with debug output)
-dnf install -y \
-    akmod-v4l2loopback-*.fc${RELEASE}.${ARCH}
-akmods --force --kernels "${KERNEL}" --kmod v4l2loopback
-modinfo /usr/lib/modules/${KERNEL}/extra/v4l2loopback/v4l2loopback.ko.xz > /dev/null \
-|| (find /var/cache/akmods/v4l2loopback/ -name \*.log -print -exec cat {} \; && exit 1)
+if [[ "${RELEASE}" -ge 42 ]]; then
+  echo "skipping v4l2loopback: made obsolete by PipeWire provided with Fedora 42"
+else
+  ### BUILD v4l2loopback (succeed or fail-fast with debug output)
+  dnf install -y \
+      akmod-v4l2loopback-*.fc${RELEASE}.${ARCH}
+  akmods --force --kernels "${KERNEL}" --kmod v4l2loopback
+  modinfo /usr/lib/modules/${KERNEL}/extra/v4l2loopback/v4l2loopback.ko.xz > /dev/null \
+  || (find /var/cache/akmods/v4l2loopback/ -name \*.log -print -exec cat {} \; && exit 1)
+fi


### PR DESCRIPTION
PipeWire should now provide the features which previously made v4l2loopback necessary. Skip the build for F42+.

Downstreams will need to adopt a similar conditional before we merge this to ensure no broken builds.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
