### PR TITLE
feat: Add acpi_call kernel module

### DIFF
--- a/Containerfile.extra
+++ b/Containerfile.extra
@@ -37,6 +37,7 @@ RUN --mount=type=bind,src=kernel_cache,dst=/tmp/kernel_cache,ro \
     if [[ "${FEDORA_MAJOR_VERSION}" -ge 41 ]]; then \
         /tmp/build-kmod-gpd-fan.sh \
     ; fi && \
+    /tmp/build-kmod-acpi-call.sh && \
     /tmp/build-kmod-ayaneo-platform.sh && \
     /tmp/build-kmod-ayn-platform.sh && \
     /tmp/build-kmod-bmi260.sh && \

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The `nvidia` stream image contains
 
 | Package | Stream | Description | Source |
 |---------|--------|-------------|--------|
+| [acpi_call](https://github.com/nix-community/acpi_call) | extra | kernel module for manually issuing ACPI method calls | [![badge](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/acpi_call-kmod/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/acpi_call-kmod) | 
 | [ayaneo-platform](https://github.com/ShadowBlip/ayaneo-platform) | extra | Linux drivers for AYANEO x86 handhelds | [![badge](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/ayaneo-platform-kmod/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/ayaneo-platform-kmod) |
 | [ayn-platform](https://github.com/ShadowBlip/ayn-platform) | extra | Linux drivers for AYN x86 handhelds | [![badge](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/ayn-platform-kmod/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/ayn-platform-kmod) |
 | [bmi260](https://github.com/hhd-dev/bmi260) | extra | kernel module driver for the Bosch BMI260 IMU | [![badge](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/bmi260-kmod/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/bmi260-kmod) |

--- a/build_files/extra/build-kmod-acpi-call.sh
+++ b/build_files/extra/build-kmod-acpi-call.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -oeux pipefail
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_ublue-os-akmods.repo /etc/yum.repos.d/
+
+### BUILD acpi_call (succeed or fail-fast with debug output)
+dnf install -y \
+    akmod-acpi_call-*.fc${RELEASE}.${ARCH}
+akmods --force --kernels "${KERNEL}" --kmod acpi_call
+modinfo /usr/lib/modules/${KERNEL}/extra/acpi_call/acpi_call.ko.xz >/dev/null ||
+    (find /var/cache/akmods/acpi_call/ -name \*.log -print -exec cat {} \; && exit 1)
+
+rm -f /etc/yum.repos.d/_copr_ublue-os-akmods.repo


### PR DESCRIPTION
Add the `acpi_call`[^1] kernel module to the `extra/` stream.

**Note about the current build failure:** This PR is written as-if the COPR build for `acpi_call-kmod` and `acpi_call-kmod-common` had already been set up at https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/ - preferably sourced from [github.com/nix-community/acpi_call](https://github.com/nix-community/acpi_call) once nix-community/acpi_call#28 has been merged[^2].

Until that PR has been merged, an example COPR build of `acpi_call-kmod` and `acpi_call-kmod-common` can be found at https://copr.fedorainfracloud.org/coprs/cr7pt0gr4ph7/acpi_call/, currently using [my own `acpi_call` repository fork](https://github.com/cr7pt0gr4ph7/acpi_call), and example image builds can be found at https://github.com/cr7pt0gr4ph7/akmods/actions.

[^1]: The `acpi_call` module allows one to manually issue ACPI method calls, which is useful to advanced users for disabling discrete Nvidia graphics cards on older laptops with hybrid Intel+Nvidia graphics where no option for this is available in the BIOS, as well as for interacting e.g. with Firmware-based fan control when no specific driver is available.

[^2]: As it appears, the people from the NixOS community now seem to be the de-facto maintainers of the `acpi_call` module.