### PR TITLE
Draft: feat(extra): add tuxedo-drivers (#129)

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -88,6 +88,7 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
 /tmp/build-kmod-framework-laptop.sh
 /tmp/build-kmod-kvmfr.sh
 /tmp/build-kmod-openrazer.sh
+/tmp/build-kmod-tuxedo-laptop.sh
 /tmp/build-kmod-v4l2loopback.sh
 /tmp/build-kmod-wl.sh
 /tmp/build-kmod-xone.sh

--- a/build_files/common/build-kmod-tuxedo-laptop.sh
+++ b/build_files/common/build-kmod-tuxedo-laptop.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+
+set "${CI:+-x}" -euo pipefail
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+curl -LsSf -o /etc/yum.repos.d/_copr_gladion136-tuxedo-drivers-kmod.repo "https://copr.fedorainfracloud.org/coprs/gladion136/tuxedo-drivers-kmod/repo/fedora-${RELEASE}/gladion136-tuxedo-drivers-kmod-fedora-${RELEASE}.repo"
+
+### BUILD tuxedo-drivers (succeed or fail-fast with debug output)
+dnf install -y \
+    "akmod-tuxedo-drivers-*.fc${RELEASE}.${ARCH}"
+akmods --force --kernels "${KERNEL}" --kmod tuxedo-drivers
+for module in /usr/lib/modules/${KERNEL}/extra/tuxedo-drivers/*.ko.xz; do
+    modinfo "$module" > /dev/null \
+    || (find /var/cache/akmods/tuxedo-drivers/ -name \*.log -print -exec cat {} \; && exit 1)
+done
+
+rm -f /etc/yum.repos.d/_copr_gladion136-tuxedo-drivers-kmod.repo


### PR DESCRIPTION
Hello, this PR adds tuxedo-drivers to akmods. It corresponding to [this](https://github.com/ublue-os/akmods/issues/129) issue. The whole thing is currently WIP, so this PR is first on draft.

Can someone help me out a bit?
Is it possible to build akmods locally to debug the errors? Since the code restructuring I have not found a way..
And is "extra" the right area for the tuxedo-driver?

Source Repository: https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers 
Spec Source Repository: https://github.com/gladion136/tuxedo-drivers-kmod
Copr: https://copr.fedorainfracloud.org/coprs/gladion136/tuxedo-drivers-kmod/