### PR TITLE
chore: fixup bazzite kernel build args

### DIFF
--- a/.github/workflows/build-bazzite.yml
+++ b/.github/workflows/build-bazzite.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         fedora_version:
-          - 41
           - 42
         kernel_flavor:
           - bazzite

--- a/.github/workflows/build-bazzite.yml
+++ b/.github/workflows/build-bazzite.yml
@@ -1,10 +1,13 @@
 name: bazzite akmods
 on:
+  merge_group:
   pull_request:
     branches:
       - main
     paths-ignore:
       - '**.md'
+  schedule:
+    - cron: '5 0 * * *'  # 0005 UTC everyday
   repository_dispatch:
     types: [bazzite-kernel-build]
   workflow_dispatch:


### PR DESCRIPTION
Spring cleaning for the bazzite kernel build options, adds cron and drops f41 builds