### PR TITLE
chore: don't build bazzite kernel for F41

### DIFF
--- a/.github/workflows/build-41.yml
+++ b/.github/workflows/build-41.yml
@@ -20,7 +20,6 @@ jobs:
         fedora_version:
           - 41
         kernel_flavor:
-          - bazzite
           - main
           - coreos-stable
           - coreos-testing


### PR DESCRIPTION
This isn't used by any downstream projects, no need to build.