### PR TITLE
fix: temporary pin of coreos-stable to 6.13.8-200.fc41.x86_64

### DIFF
--- a/.github/actions/get-kernel-version/action.yml
+++ b/.github/actions/get-kernel-version/action.yml
@@ -47,9 +47,9 @@ runs:
           coreos_version=${1}
           image_linux=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:${coreos_version} | jq -r '.Labels["ostree.linux"]')
           # Pin a kernel here, gross workaround TODO: Make this cleaner
-          # if [[ "${{ inputs.kernel_flavor }}" == "coreos-stable" ]]; then
-          #    image_linux="6.11.3-300.fc41.x86_64"
-          # fi
+          if [[ "${{ inputs.kernel_flavor }}" == "coreos-stable" ]]; then
+             image_linux="6.13.8-200.fc41.x86_64"
+          fi
           major_minor_patch=$(echo $image_linux | grep -oP '^\d+\.\d+\.\d+')
           kernel_rel_part=$(echo $image_linux | grep -oP '^\d+\.\d+\.\d+\-\K([123][0]{2})')
           arch=$(echo $image_linux | grep -oP 'fc\d+\.\K.*$')

--- a/build_files/shared/build-prep.sh
+++ b/build_files/shared/build-prep.sh
@@ -85,7 +85,8 @@ if [[ "${KERNEL_FLAVOR}" =~ "coreos" ]]; then
         git \
         jq \
         libtool \
-        ncompress
+        ncompress \
+        python-cffi
 fi
 
 # protect against incorrect permissions in tmp dirs which can break akmods builds


### PR DESCRIPTION
since coreos-stable is on F42 with a rawhid kernel, this at least lets us try to pin a working version for akmods builds
