### PR TITLE
fix: only use testing/rawhide for F43+

### DIFF
--- a/build_files/shared/build-prep.sh
+++ b/build_files/shared/build-prep.sh
@@ -31,8 +31,8 @@ else
         "${RPMFUSION_MIRROR_RPMS}"/nonfree/fedora/rpmfusion-nonfree-release-"${RELEASE}".noarch.rpm \
         fedora-repos-archive
 
-    # after F42 launches, bump to 43
-    if [[ "${FEDORA_MAJOR_VERSION}" -ge 42 ]]; then
+    # after F43 launches, bump to 44
+    if [[ "${FEDORA_MAJOR_VERSION}" -ge 43 ]]; then
         # pre-release rpmfusion is in a different location
         sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
         # pre-release rpmfusion needs to enable testing

--- a/build_files/shared/test-prep.sh
+++ b/build_files/shared/test-prep.sh
@@ -53,8 +53,8 @@ else
         "${RPMFUSION_MIRROR_RPMS}"/nonfree/fedora/rpmfusion-nonfree-release-"${RELEASE}".noarch.rpm \
         fedora-repos-archive
 
-    # after F42 launches, bump to 43
-    if [[ "${FEDORA_MAJOR_VERSION}" -ge 42 ]]; then
+    # after F43 launches, bump to 44
+    if [[ "${FEDORA_MAJOR_VERSION}" -ge 43 ]]; then
         # pre-release rpmfusion is in a different location
         sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
         # pre-release rpmfusion needs to enable testing
@@ -68,8 +68,8 @@ else
         sed -i "s%^#baseurl=http://download1.rpmfusion.org%baseurl=${RPMFUSION_MIRROR}%" /etc/yum.repos.d/rpmfusion-*.repo
     fi
 
-    # after F42 launches, bump to 43
-    if [[ "${RELEASE}" -ge 42 ]]; then
+    # after F43 launches, bump to 44
+    if [[ "${RELEASE}" -ge 43 ]]; then
         COPR_RELEASE="rawhide"
     else
         COPR_RELEASE="${RELEASE}"


### PR DESCRIPTION
This fixes the issue where newer than expected versions of akmods were being built for F42 (most recently with v4l2loopback).