### PR TITLE
chore: re-enable centos-bootc:stream9

### DIFF
--- a/.github/workflows/build-centos.yml
+++ b/.github/workflows/build-centos.yml
@@ -22,7 +22,7 @@ jobs:
           - centos-hsk
         fedora_version:
           - stream10
-        #  - stream9 # disabled at least until nvidia builds work again
+          - stream9
         exclude:
           - kernel_flavor: centos-hsk
             fedora_version: stream9


### PR DESCRIPTION
Re-enabling CentOS bootc 9 builds now that nvidia builds thanks to a quick fix from Negativo17! https://github.com/negativo17/nvidia-driver/issues/178