### PR TITLE
chore: remove `--squash` and use COPY instead

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -105,13 +105,12 @@ jobs:
           # DEBUG: get character count of key
           wc -c certs/private_key.priv
           wc -c certs/private_key_2.priv
-        
-      - name: Build Image
-        id: build
-        run: just build
 
       - name: Test Image
         run: just test
+        
+      - name: Build Image
+        run: just build
 
       - name: Push and Sign Image
         if: contains(fromJson('["schedule", "workflow_dispatch", "merge_group"]'), github.event_name)

--- a/Containerfile.in
+++ b/Containerfile.in
@@ -177,7 +177,7 @@ set "${CI+-x}" -euo pipefail
 /tmp/build-post.sh
 RUNEOF
 
-FROM scratch AS RPMS
+FROM scratch AS RPM_CACHE
 
 COPY --from=builder /var/cache/kernel-rpms /kernel-rpms
 COPY --from=builder /var/cache/rpms /rpms
@@ -194,8 +194,8 @@ ARG VERSION_ARG
 ENV CI=1
 #endif
 
-COPY --from=RPMS /kernel-rpms /tmp/kernel_cache
-COPY --from=RPMS /rpms /tmp/akmods-rpms
+COPY --from=RPM_CACHE /kernel-rpms /tmp/kernel_cache
+COPY --from=RPM_CACHE /rpms /tmp/akmods-rpms
 
 COPY build_files/test/test-prep.sh /tmp/
 COPY certs /tmp/certs
@@ -209,3 +209,6 @@ RUNEOF
 
 COPY build_files/test/check-signatures.sh /tmp/
 CMD ["/tmp/check-signatures.sh"]
+
+FROM scratch AS RPMS
+COPY --from=RPM_CACHE / /

--- a/Justfile
+++ b/Justfile
@@ -268,7 +268,7 @@ build: (cache-kernel-version) (fetch-kernel)
         "--tag" "{{ akmods_name + ':' + kernel_flavor + '-' + version + '-' + shell("jq -r '.kernel_release' < $1", version_json) }}"
     )
 
-    {{ podman }} build -f Containerfile.in --volume {{ KCPATH }}:/tmp/kernel_cache:ro "${CPP_FLAGS[@]}" "${LABELS[@]}" "${TAGS[@]}" --target RPMS --squash {{ justfile_dir () }}
+    {{ podman }} build -f Containerfile.in --volume {{ KCPATH }}:/tmp/kernel_cache:ro "${CPP_FLAGS[@]}" "${LABELS[@]}" "${TAGS[@]}" --target RPMS {{ justfile_dir () }}
 
 # Test Cached Akmod RPMs
 [group('Build')]


### PR DESCRIPTION
`--squash` requires us to rebuild a significant portion. Instead flatten with COPY.

Additionally, put `just test` first to build and test the image, then `just build` to flatten and tag the image.

Signed-off-by: m2 <69128853+m2Giles@users.noreply.github.com>

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
