### PR TITLE
fix: quick and dirty pin of nvidia kmod to fix builds

### DIFF
--- a/build_files/nvidia/build-kmod-nvidia.sh
+++ b/build_files/nvidia/build-kmod-nvidia.sh
@@ -28,7 +28,8 @@ dnf install -y \
 # Either successfully build and install the kernel modules, or fail early with debug output
 rpm -qa |grep nvidia
 KERNEL_VERSION="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
-NVIDIA_AKMOD_VERSION="$(basename "$(rpm -q "akmod-nvidia" --queryformat '%{VERSION}-%{RELEASE}')" ".${DIST}")"
+# NVIDIA_AKMOD_VERSION="$(basename "$(rpm -q "akmod-nvidia" --queryformat '%{VERSION}-%{RELEASE}')" ".${DIST}")"
+NVIDIA_AKMOD_VERSION="$(basename "$(rpm -q "akmod-nvidia" --queryformat '575.64.03-%{RELEASE}')" ".${DIST}")"
 
 sed -i "s/^MODULE_VARIANT=.*/MODULE_VARIANT=$KERNEL_MODULE_TYPE/" /etc/nvidia/kernel.conf
 


### PR DESCRIPTION
fixes https://github.com/ublue-os/bluefin/issues/2845

builds are failing for nvidia on bluefin