### PR TITLE
feat: replace centos-hsk kernel with centos-kmodsig

### DIFF
--- a/.github/workflows/build-akmods-centos-kmodsig.yml
+++ b/.github/workflows/build-akmods-centos-kmodsig.yml
@@ -4,7 +4,7 @@
 #
 # Generate the workflow by running `just generate-workflows` at git root
 # Modify the inputs in workflow-templates
-name: Build CENTOS-HSK akmods
+name: Build CENTOS-KMODSIG akmods
 on:
   merge_group:
   pull_request:
@@ -16,8 +16,8 @@ on:
     - cron: '05 0 * * *'  # 0005 UTC everyday
   workflow_dispatch:
 jobs:
-  cache_kernel_centos-hsk_10:
-    name: Cache centos-hsk (10)
+  cache_kernel_centos-kmodsig_10:
+    name: Cache centos-kmodsig (10)
     uses: ./.github/workflows/reusable-cache-kernel.yml
     secrets: inherit
     permissions:
@@ -25,56 +25,56 @@ jobs:
       contents: read
       packages: write
     with:
-      kernel_flavor: centos-hsk
+      kernel_flavor: centos-kmodsig
       version: 10
-  build-centos-hsk_10_nvidia:
-    name: Build nvidia centos-hsk (10)
+  build-centos-kmodsig_10_nvidia:
+    name: Build nvidia centos-kmodsig (10)
     uses: ./.github/workflows/reusable-build.yml
     secrets: inherit
     permissions:
       actions: read
       contents: read
       packages: write
-    needs: cache_kernel_centos-hsk_10
+    needs: cache_kernel_centos-kmodsig_10
     with:
       version: 10
-      kernel_flavor: centos-hsk
+      kernel_flavor: centos-kmodsig
       akmods_target: nvidia
-      kernel_cache_key: ${{ needs.cache_kernel_centos-hsk_10.outputs.KCKEY }}
-  build-centos-hsk_10_nvidia-open:
-    name: Build nvidia-open centos-hsk (10)
+      kernel_cache_key: ${{ needs.cache_kernel_centos-kmodsig_10.outputs.KCKEY }}
+  build-centos-kmodsig_10_nvidia-open:
+    name: Build nvidia-open centos-kmodsig (10)
     uses: ./.github/workflows/reusable-build.yml
     secrets: inherit
     permissions:
       actions: read
       contents: read
       packages: write
-    needs: cache_kernel_centos-hsk_10
+    needs: cache_kernel_centos-kmodsig_10
     with:
       version: 10
-      kernel_flavor: centos-hsk
+      kernel_flavor: centos-kmodsig
       akmods_target: nvidia-open
-      kernel_cache_key: ${{ needs.cache_kernel_centos-hsk_10.outputs.KCKEY }}
-  build-centos-hsk_10_zfs:
-    name: Build zfs centos-hsk (10)
+      kernel_cache_key: ${{ needs.cache_kernel_centos-kmodsig_10.outputs.KCKEY }}
+  build-centos-kmodsig_10_zfs:
+    name: Build zfs centos-kmodsig (10)
     uses: ./.github/workflows/reusable-build.yml
     secrets: inherit
     permissions:
       actions: read
       contents: read
       packages: write
-    needs: cache_kernel_centos-hsk_10
+    needs: cache_kernel_centos-kmodsig_10
     with:
       version: 10
-      kernel_flavor: centos-hsk
+      kernel_flavor: centos-kmodsig
       akmods_target: zfs
-      kernel_cache_key: ${{ needs.cache_kernel_centos-hsk_10.outputs.KCKEY }}
-  check-centos-hsk_10:
-    name: Check centos-hsk (10)
+      kernel_cache_key: ${{ needs.cache_kernel_centos-kmodsig_10.outputs.KCKEY }}
+  check-centos-kmodsig_10:
+    name: Check centos-kmodsig (10)
     permissions:
       actions: read
       contents: read
-    needs: [build-centos-hsk_10_nvidia,build-centos-hsk_10_nvidia-open,build-centos-hsk_10_zfs]
+    needs: [build-centos-kmodsig_10_nvidia,build-centos-kmodsig_10_nvidia-open,build-centos-kmodsig_10_zfs]
     runs-on: ubuntu-24.04
     if: always()
     steps:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       kernel_flavor:
-        description: "The Kernel flavor: main, bazzite, coreos-stable, centos-hsk, longterm-6.12, etc"
+        description: "The Kernel flavor: main, bazzite, coreos-stable, centos-kmodsig, longterm-6.12, etc"
         required: true
         type: string
       version:
@@ -34,7 +34,7 @@ on:
         required: false
         type: string
       kernel_flavor:
-        description: "The Kernel flavor: main, bazzite, coreos-stable, centos-hsk, longterm-6.12, etc"
+        description: "The Kernel flavor: main, bazzite, coreos-stable, centos-kmodsig, longterm-6.12, etc"
         required: true
         type: string
       version:

--- a/.github/workflows/reusable-cache-kernel.yml
+++ b/.github/workflows/reusable-cache-kernel.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       kernel_flavor:
-        description: "The Kernel flavor: main, bazzite, coreos-stable, centos-hsk, longterm-6.12, etc"
+        description: "The Kernel flavor: main, bazzite, coreos-stable, centos-kmodsig, longterm-6.12, etc"
         required: true
         type: string
       version:
@@ -26,7 +26,7 @@ on:
         required: false
         type: string
       kernel_flavor:
-        description: "The Kernel flavor: main, bazzite, coreos-stable, centos-hsk, longterm-6.12, etc"
+        description: "The Kernel flavor: main, bazzite, coreos-stable, centos-kmodsig, longterm-6.12, etc"
         required: true
         type: string
       version:

--- a/Justfile
+++ b/Justfile
@@ -120,7 +120,7 @@ get-kernel-version:
         "centos-kmodsig")
             $dnf -y install centos-release-kmods-kernel >&2
             $dnf makecache >&2
-            linux=$($dnf repoquery --enablerepo="centos-kmods-kernel" --whatprovides kernel | sort -V | tail -n1 | sed 's/.*://')
+            linux=$($dnf repoquery --enablerepo="centos-kmods-kernel" --whatprovides kernel-core | sort -V | tail -n1 | sed 's/.*://')
             ;;
         "coreos-stable")
             coreos_kernel stable

--- a/Justfile
+++ b/Justfile
@@ -117,7 +117,7 @@ get-kernel-version:
             $dnf makecache >&2
             linux=$($dnf repoquery --whatprovides kernel | sort -V | tail -n1 | sed 's/.*://')
             ;;
-        "centos-hsk")
+        "centos-kmodsig")
             $dnf -y install centos-release-hyperscale-kernel >&2
             $dnf makecache >&2
             linux=$($dnf repoquery --enablerepo="centos-hyperscale" --whatprovides kernel | sort -V | tail -n1 | sed 's/.*://')

--- a/Justfile
+++ b/Justfile
@@ -118,9 +118,9 @@ get-kernel-version:
             linux=$($dnf repoquery --whatprovides kernel | sort -V | tail -n1 | sed 's/.*://')
             ;;
         "centos-kmodsig")
-            $dnf -y install centos-release-hyperscale-kernel >&2
+            $dnf -y install centos-release-kmods-kernel >&2
             $dnf makecache >&2
-            linux=$($dnf repoquery --enablerepo="centos-hyperscale" --whatprovides kernel | sort -V | tail -n1 | sed 's/.*://')
+            linux=$($dnf repoquery --enablerepo="centos-kmods-kernel" --whatprovides kernel | sort -V | tail -n1 | sed 's/.*://')
             ;;
         "coreos-stable")
             coreos_kernel stable

--- a/fetch-kernel.sh
+++ b/fetch-kernel.sh
@@ -111,12 +111,18 @@ install -Dm644 "${KCWD}"/certs/public_key.crt "$PUBLIC_KEY_PATH"
 install -Dm644 "${KCWD}"/certs/private_key.priv "$PRIVATE_KEY_PATH"
 
 ls -la /
-dnf install -y \
-    /"${kernel_name}-$kernel_version.rpm" \
-    /"${kernel_name}-core-$kernel_version.rpm" \
-    /"${kernel_name}-modules-$kernel_version.rpm" \
-    /"${kernel_name}-modules-core-$kernel_version.rpm" \
-    /"${kernel_name}-modules-extra-$kernel_version.rpm"
+if [[ "${kernel_flavor}" == "centos-kmodsig" ]]; then
+  dnf install -y \
+      /"${kernel_name}-$kernel_version.rpm" \
+      /"${kernel_name}-modules-$kernel_version.rpm"
+else
+  dnf install -y \
+      /"${kernel_name}-$kernel_version.rpm" \
+      /"${kernel_name}-core-$kernel_version.rpm" \
+      /"${kernel_name}-modules-$kernel_version.rpm" \
+      /"${kernel_name}-modules-core-$kernel_version.rpm" \
+      /"${kernel_name}-modules-extra-$kernel_version.rpm"
+fi
 
 # Strip Signatures from non-fedora Kernels
 if [[ ${kernel_flavor} =~ main|coreos|centos ]]; then

--- a/fetch-kernel.sh
+++ b/fetch-kernel.sh
@@ -59,17 +59,17 @@ elif [[ "${kernel_flavor}" == "centos" ]]; then
     curl -#fLO https://mirror.stream.centos.org/"$CENTOS_VER"-stream/BaseOS/"$ARCH"/os/Packages/kernel-uki-virt-"$kernel_version".rpm
     curl -#fLO https://mirror.stream.centos.org/"$CENTOS_VER"-stream/AppStream/"$ARCH"/os/Packages/kernel-devel-"$kernel_version".rpm
     curl -#fLO https://mirror.stream.centos.org/"$CENTOS_VER"-stream/AppStream/"$ARCH"/os/Packages/kernel-devel-matched-"$kernel_version".rpm
-elif [[ "${kernel_flavor}" == "centos-hsk" ]]; then
-    dnf -y install centos-release-hyperscale-kernel
-    dnf download -y --enablerepo="centos-hyperscale" \
+elif [[ "${kernel_flavor}" == "centos-kmodsig" ]]; then
+    dnf -y install centos-release-kmods-kernel
+    dnf download -y --enablerepo="centos-kmods-kernel" \
         kernel-"${kernel_version}" \
-        kernel-core-"${kernel_version}" \
         kernel-modules-"${kernel_version}" \
-        kernel-modules-core-"${kernel_version}" \
-        kernel-modules-extra-"${kernel_version}" \
         kernel-devel-"${kernel_version}" \
-        kernel-devel-matched-"${kernel_version}" \
-        kernel-uki-virt-"${kernel_version}"
+        kernel-devel-matched-"${kernel_version}"
+        #kernel-core-"${kernel_version}" \
+        #kernel-modules-core-"${kernel_version}" \
+        #kernel-modules-extra-"${kernel_version}" \
+        #kernel-uki-virt-"${kernel_version}"
 elif [[ "${kernel_flavor}" =~ "longterm" ]]; then
     dnf download -y --enablerepo="copr:copr.fedorainfracloud.org:kwizart:kernel-${kernel_flavor}" \
         kernel-longterm-"${kernel_version}" \

--- a/fetch-kernel.sh
+++ b/fetch-kernel.sh
@@ -63,10 +63,10 @@ elif [[ "${kernel_flavor}" == "centos-kmodsig" ]]; then
     dnf -y install centos-release-kmods-kernel
     dnf download -y --enablerepo="centos-kmods-kernel" \
         kernel-"${kernel_version}" \
+        kernel-core-"${kernel_version}" \
         kernel-modules-"${kernel_version}" \
         kernel-devel-"${kernel_version}" \
         kernel-devel-matched-"${kernel_version}"
-        #kernel-core-"${kernel_version}" \
         #kernel-modules-core-"${kernel_version}" \
         #kernel-modules-extra-"${kernel_version}" \
         #kernel-uki-virt-"${kernel_version}"

--- a/fetch-kernel.sh
+++ b/fetch-kernel.sh
@@ -114,6 +114,7 @@ ls -la /
 if [[ "${kernel_flavor}" == "centos-kmodsig" ]]; then
   dnf install -y \
       /"${kernel_name}-$kernel_version.rpm" \
+      /"${kernel_name}-core-$kernel_version.rpm" \
       /"${kernel_name}-modules-$kernel_version.rpm"
 else
   dnf install -y \

--- a/fetch-kernel.sh
+++ b/fetch-kernel.sh
@@ -25,7 +25,10 @@ fi
 dnf -y install --setopt=install_weak_deps=False rpmrebuild sbsigntools
 
 case "$kernel_flavor" in
-    "bazzite"|"centos"*|"coreos"*|"main")
+    "bazzite"|"centos"|"coreos"*|"main")
+        ;;
+    "centos-kmodsig")
+        dnf -y install centos-release-kmods-kernel
         ;;
     "longterm"*)
         dnf -y copr enable kwizart/kernel-"${kernel_flavor}"
@@ -47,8 +50,6 @@ if [[ "${kernel_flavor}" == "bazzite" ]]; then
     curl -#fLO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-devel-matched-"$kernel_version".rpm
     curl -#fLO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-tools-"$kernel_version".rpm
     curl -#fLO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-tools-libs-"$kernel_version".rpm
-    # curl -#fLO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-uki-virt-"$kernel_version".rpm
-    # curl -LO https://github.com/bazzite-org/kernel-bazzite/releases/download/"$build_tag"/kernel-uki-virt-addons-"$kernel_version".rpm
 elif [[ "${kernel_flavor}" == "centos" ]]; then
     # Using curl instead of dnf download for https links
     curl -#fLO https://mirror.stream.centos.org/"$CENTOS_VER"-stream/BaseOS/"$ARCH"/os/Packages/kernel-"$kernel_version".rpm
@@ -60,16 +61,12 @@ elif [[ "${kernel_flavor}" == "centos" ]]; then
     curl -#fLO https://mirror.stream.centos.org/"$CENTOS_VER"-stream/AppStream/"$ARCH"/os/Packages/kernel-devel-"$kernel_version".rpm
     curl -#fLO https://mirror.stream.centos.org/"$CENTOS_VER"-stream/AppStream/"$ARCH"/os/Packages/kernel-devel-matched-"$kernel_version".rpm
 elif [[ "${kernel_flavor}" == "centos-kmodsig" ]]; then
-    dnf -y install centos-release-kmods-kernel
     dnf download -y --enablerepo="centos-kmods-kernel" \
         kernel-"${kernel_version}" \
         kernel-core-"${kernel_version}" \
         kernel-modules-"${kernel_version}" \
         kernel-devel-"${kernel_version}" \
         kernel-devel-matched-"${kernel_version}"
-        #kernel-modules-core-"${kernel_version}" \
-        #kernel-modules-extra-"${kernel_version}" \
-        #kernel-uki-virt-"${kernel_version}"
 elif [[ "${kernel_flavor}" =~ "longterm" ]]; then
     dnf download -y --enablerepo="copr:copr.fedorainfracloud.org:kwizart:kernel-${kernel_flavor}" \
         kernel-longterm-"${kernel_version}" \
@@ -113,6 +110,7 @@ install -Dm644 "${KCWD}"/certs/private_key.priv "$PRIVATE_KEY_PATH"
 ls -la /
 if [[ "${kernel_flavor}" == "centos-kmodsig" ]]; then
   dnf install -y \
+      dracut \
       /"${kernel_name}-$kernel_version.rpm" \
       /"${kernel_name}-core-$kernel_version.rpm" \
       /"${kernel_name}-modules-$kernel_version.rpm"

--- a/fetch-kernel.sh
+++ b/fetch-kernel.sh
@@ -22,7 +22,7 @@ if [[ "$kernel_flavor" =~ "centos" ]]; then
     dnf config-manager --set-enabled crb
     dnf -y install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${CENTOS_VER}.noarch.rpm"
 fi
-dnf -y install --setopt=install_weak_deps=False rpmrebuild sbsigntools
+dnf -y install --setopt=install_weak_deps=False dracut rpmrebuild sbsigntools
 
 case "$kernel_flavor" in
     "bazzite"|"centos"|"coreos"*|"main")
@@ -110,7 +110,6 @@ install -Dm644 "${KCWD}"/certs/private_key.priv "$PRIVATE_KEY_PATH"
 ls -la /
 if [[ "${kernel_flavor}" == "centos-kmodsig" ]]; then
   dnf install -y \
-      dracut \
       /"${kernel_name}-$kernel_version.rpm" \
       /"${kernel_name}-core-$kernel_version.rpm" \
       /"${kernel_name}-modules-$kernel_version.rpm"

--- a/images.yaml
+++ b/images.yaml
@@ -63,7 +63,7 @@ images:
     centos:
       !!merge <<:
         - *server-build-group
-    centos-hsk:
+    centos-kmodsig:
       !!merge <<:
         - *server-build-group
   41:


### PR DESCRIPTION
This replaces the Hyperscale (hsk) kernel (which is no longer used by Bluefin LTS) with the CentOS Kmods SIG kernel, now used for Bluefin LTS (HWE).

Closes: #349
Closes: #370

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
