### PR TITLE
fix: allow varied coreos kernel release matching

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -82,9 +82,11 @@ get-kernel-version:
         if grep -qv "200 OK" <<< "${HTTP_RESP}"; then
             echo "Koji failed to find $coreos_version kernel: $kernel_version" >&2
             case "$kernel_rel_part" in
-                "300") kernel_rel_part="200" ;;
-                "200") kernel_rel_part="100" ;;
-                "100") ;;
+                30[0-9]|20[0-9])
+                    kernel_rel_part_new=$((10#$kernel_rel_part - 100))
+                    kernel_rel_part=$(printf "%03d" "$kernel_rel_part_new")   # zero pad to 3 digits
+                    ;;
+                10[0-9]) ;;
                 *) echo "unexpected kernel_rel_part ${kernel_rel_part}" >&2 ;;
             esac
             kernel_rel="$kernel_rel_part.fc{{ version }}"


### PR DESCRIPTION
This allows kernel releases like -201, -202, etc
rather than requiring exactly -200, -300.

Should allow for most of the cases where CoreOS team uses a slightly different release for their kernels.



<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
