### PR TITLE
feat: remove F42 builds for longterm-6.12

### DIFF
--- a/.github/workflows/build-akmods-longterm-6.12.yml
+++ b/.github/workflows/build-akmods-longterm-6.12.yml
@@ -28,6 +28,21 @@ jobs:
       architecture: '["aarch64","x86_64"]'
       kernel_flavor: longterm-6.12
       version: 43
+  build-longterm-6-12_43_common:
+    name: Build common longterm-6.12 (43)
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+    needs: cache_kernel_longterm-6-12_43
+    with:
+      akmods_target: common
+      architecture: '["aarch64","x86_64"]'
+      kernel_cache_key: ${{ needs.cache_kernel_longterm-6-12_43.outputs.KCKEY }}
+      kernel_flavor: longterm-6.12
+      version: 43
   build-longterm-6-12_43_nvidia:
     name: Build nvidia longterm-6.12 (43)
     uses: ./.github/workflows/reusable-build.yml
@@ -78,7 +93,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    needs: [build-longterm-6-12_43_nvidia,build-longterm-6-12_43_nvidia-open,build-longterm-6-12_43_zfs]
+    needs: [build-longterm-6-12_43_common,build-longterm-6-12_43_nvidia,build-longterm-6-12_43_nvidia-open,build-longterm-6-12_43_zfs]
     runs-on: ubuntu-24.04
     if: always()
     steps:


### PR DESCRIPTION
The longterm-6.12 kernel was added for Cayo and now is planned for use in uCore. As it was always meant for server use it does not need the common kmod builds, except that uCore's build process does expect them for now.

It only needs to build for F43 now that Fedora CoreOS (and thus uCore) is on F43.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
