### PR TITLE
chore: free disk space on host from container

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -84,7 +84,7 @@ jobs:
               /usr/lib/llvm-* /usr/local/julia* /usr/local/lib/android /usr/share/dotnet \
               /usr/share/swift /usr/local/.ghcup /usr/lib/firefox /opt/google/chrome \
               /opt/microsoft/msedge \
-              | xargs -0 -n1 -P4 rm -vrf
+              | xargs -0 -n1 -P4 rm -rf
           df -h
 
       - name: Checkout Repo


### PR DESCRIPTION
Free disk space on the builder using the [same method as bazzite-kernel](https://github.com/bazzite-org/kernel-bazzite/blob/bazzite-6.17/.github/workflows/build.yml#L87-L99), however in this case, first the host root filesystem must be mounted into the container.

Also, I had trouble disabling swap and removing swapfile from within the container, but this approach still gains a significant amount of disk back for build operations.