### PR TITLE
fix: ensure ZFS_MINOR_VERSION pin is respected

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -14,10 +14,6 @@ ARG CI=1
 ARG KMOD_REPO_ARG
 #endif /* NVIDIA */
 
-#ifdef ZFS
-ARG ZFS_MINOR_VERSION="2.3"
-#endif /* ZFS */
-
 # /*
 # common copy/add
 # */
@@ -64,6 +60,10 @@ ARG CI=1
 #ifdef NVIDIA 
 ARG KMOD_REPO_ARG
 #endif /* NVIDIA */
+
+#ifdef ZFS
+ARG ZFS_MINOR_VERSION="2.3"
+#endif /* ZFS */
 
 #if defined COMMON
 # /*

--- a/build_files/zfs/build-kmod-zfs.sh
+++ b/build_files/zfs/build-kmod-zfs.sh
@@ -11,6 +11,7 @@ cd /tmp
 # Use cURL to fetch the given URL, saving the response to `data.json`
 curl "https://api.github.com/repos/openzfs/zfs/releases" -o data.json
 ZFS_VERSION=$(jq -r --arg ZMV "zfs-${ZFS_MINOR_VERSION}" '[ .[] | select(.prerelease==false and .draft==false) | select(.tag_name | startswith($ZMV))][0].tag_name' data.json|cut -f2- -d-)
+echo "ZFS_MINOR_VERSION==$ZFS_MINOR_VERSION"
 echo "ZFS_VERSION==$ZFS_VERSION"
 
 


### PR DESCRIPTION
The ARG ZFS_MINOR_VERSION was too early in Containerfile, before the last FROM statement before building ZFS kmod, thus it was ignored by the RUN which built the kmod.

This moves it into the correct location and adds an echo to debug what the provided version actually was.

Since zpools created on 2.4.0 can still be imported in 2.3.5 (verified in local testing), this will not only ensure we don't have this occur again, but revert to 2.3.x for now.


Note that CentOS failures are related to NVIDIA and not this change.