### PR TITLE
fix: change improper sets when CI=""

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -44,7 +44,7 @@ COPY build_files/prep /tmp/
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
-set "${CI+-x}" -euo pipefail
+set ${CI+-x} -euo pipefail
 ls -sh /tmp/kernel_cache
 /tmp/build-prep.sh
 RUNEOF
@@ -77,7 +77,7 @@ COPY build_files/common /tmp/
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
-set "${CI+-x}" -euo pipefail
+set ${CI+-x} -euo pipefail
 /tmp/build-ublue-os-akmods-addons.sh
 cp /tmp/ublue-os-akmods-addons/rpmbuild/RPMS/noarch/ublue-os-akmods-addons*.rpm /var/cache/rpms/ublue-os/
 RUNEOF
@@ -100,7 +100,7 @@ COPY build_files/extra /tmp/
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
-set "${CI+-x}" -euo pipefail
+set ${CI+-x} -euo pipefail
 /tmp/build-kmod-gcadapter_oc.sh
 /tmp/build-kmod-zenergy.sh
 /tmp/build-kmod-ryzen-smu.sh
@@ -147,7 +147,7 @@ COPY build_files/zfs /tmp/
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
-set "${CI+-x}" -euo pipefail
+set ${CI+-x} -euo pipefail
 if [[ "${KERNEL_FLAVOR}" =~ (coreos|longterm) ]]; then
     /tmp/build-ublue-os-ucore-addons.sh
     cp /tmp/ublue-os-ucore-addons/rpmbuild/RPMS/noarch/ublue-os-ucore-addons*.rpm /var/cache/rpms/ucore/
@@ -156,7 +156,7 @@ RUNEOF
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
-set "${CI+-x}" -euo pipefail
+set ${CI+-x} -euo pipefail
 /tmp/build-kmod-zfs.sh
 RUNEOF
 #endif
@@ -168,7 +168,7 @@ COPY build_files/post /tmp/
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
-set "${CI+-x}" -euo pipefail
+set ${CI+-x} -euo pipefail
 #ifdef ZFS
 /tmp/dual-sign-zfs.sh
 #else
@@ -207,7 +207,7 @@ COPY certs /tmp/certs
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
-set "${CI+-x}" -euo pipefail
+set ${CI+-x} -euo pipefail
 /tmp/test-prep.sh
 RUNEOF
 

--- a/Justfile
+++ b/Justfile
@@ -59,7 +59,7 @@ clean:
 [private]
 get-kernel-version:
     #!/usr/bin/env bash
-    set "${CI:+-x}" -euo pipefail
+    set ${CI:+-x} -euo pipefail
     if [[ {{ kernel_flavor }} =~ centos|longterm ]]; then
         {{ podman }} pull --retry 3 "{{ builder }}" >&2
         builder=$({{ podman }} run --entrypoint /bin/bash -dt "{{ builder }}")
@@ -285,7 +285,7 @@ fetch-kernel: (cache-kernel-version)
     #!/usr/bin/env bash
     {{ if path_exists(version_json) != 'true' { error('Need to run just cache-kernel-version first for dry-run') } else { '' } }}
     {{ if path_exists( KCPATH / shell("jq -r '.kernel_name + \"-\" + .kernel_release + \".rpm\"' < $1", version_json)) == 'true' { 'exit 0' } else { '' } }}
-    set "${CI:+-x}" -euo pipefail
+    set ${CI:+-x} -euo pipefail
 
     # Pull Build Image
     {{ podman }} pull --retry 3 "{{ builder }}" >&2
@@ -315,7 +315,7 @@ fetch-kernel: (cache-kernel-version)
 [group('Build')]
 build: (cache-kernel-version) (fetch-kernel)
     #!/usr/bin/env bash
-    set "${CI:+-x}" -euo pipefail
+    set ${CI:+-x} -euo pipefail
     {{ if path_exists(version_json) != 'true' { error('Need to run just cache-kernel-version first for dry-run') } else { '' } }}
     {{ if path_exists( KCPATH / shell("jq -r '.kernel_name + \"-\" + .kernel_release + \".rpm\"' < $1", version_json)) != 'true' { error('No Cached RPMs') } else { '' } }}
     CPP_FLAGS=(
@@ -365,7 +365,7 @@ build: (cache-kernel-version) (fetch-kernel)
 [group('Build')]
 test: (cache-kernel-version) (fetch-kernel)
     #!/usr/bin/env bash
-    set "${CI:+-x}" -euo pipefail
+    set ${CI:+-x} -euo pipefail
     {{ if path_exists(version_json) != 'true' { error('Need to run just cache-kernel-version first for dry-run') } else { '' } }}
     {{ if path_exists( KCPATH / shell("jq -r '.kernel_name + \"-\" + .kernel_release + \".rpm\"' < $1", version_json)) != 'true' { error('No Cached RPMs') } else { '' } }}
     CPP_FLAGS=(

--- a/build_files/common/build-kmod-framework-laptop.sh
+++ b/build_files/common/build-kmod-framework-laptop.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/common/build-kmod-openrazer.sh
+++ b/build_files/common/build-kmod-openrazer.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/common/build-kmod-v4l2loopback.sh
+++ b/build_files/common/build-kmod-v4l2loopback.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/common/build-kmod-wl.sh
+++ b/build_files/common/build-kmod-wl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/common/build-kmod-xone.sh
+++ b/build_files/common/build-kmod-xone.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/common/build-kmod-xpadneo.sh
+++ b/build_files/common/build-kmod-xpadneo.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/common/build-ublue-os-akmods-addons.sh
+++ b/build_files/common/build-ublue-os-akmods-addons.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ### BUILD UBLUE AKMODS-ADDONS RPM
 # ensure a higher priority is set for our ublue akmods COPR to pull deps from it over other sources (99 is default)

--- a/build_files/extra/build-kmod-evdi.sh
+++ b/build_files/extra/build-kmod-evdi.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/extra/build-kmod-gcadapter_oc.sh
+++ b/build_files/extra/build-kmod-gcadapter_oc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/extra/build-kmod-hid-fanatecff.sh
+++ b/build_files/extra/build-kmod-hid-fanatecff.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/extra/build-kmod-hid-tmff2.sh
+++ b/build_files/extra/build-kmod-hid-tmff2.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/extra/build-kmod-kvmfr.sh
+++ b/build_files/extra/build-kmod-kvmfr.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/extra/build-kmod-new-lg4ff.sh
+++ b/build_files/extra/build-kmod-new-lg4ff.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/extra/build-kmod-ryzen-smu.sh
+++ b/build_files/extra/build-kmod-ryzen-smu.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/extra/build-kmod-sc0710.sh
+++ b/build_files/extra/build-kmod-sc0710.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/extra/build-kmod-system76-io.sh
+++ b/build_files/extra/build-kmod-system76-io.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME:-kernel}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/extra/build-kmod-system76.sh
+++ b/build_files/extra/build-kmod-system76.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME:-kernel}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/extra/build-kmod-t150-driver.sh
+++ b/build_files/extra/build-kmod-t150-driver.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/extra/build-kmod-zenergy.sh
+++ b/build_files/extra/build-kmod-zenergy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"

--- a/build_files/nvidia/build-kmod-nvidia.sh
+++ b/build_files/nvidia/build-kmod-nvidia.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KMOD_REPO="${1:-nvidia}"

--- a/build_files/nvidia/build-ublue-os-nvidia-addons.sh
+++ b/build_files/nvidia/build-ublue-os-nvidia-addons.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 curl -L https://negativo17.org/repos/epel-nvidia.repo \
     -o /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/negativo17-epel-nvidia.repo

--- a/build_files/nvidia/download-nvidia-rpms.sh
+++ b/build_files/nvidia/download-nvidia-rpms.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ARCH="$(rpm -E '%_arch')"
 KMOD_REPO="${1:-nvidia}"

--- a/build_files/post/build-post.sh
+++ b/build_files/post/build-post.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 # Ensure packages get copied to /var/cache/rpms
 pushd /root/rpmbuild/RPMS/"$(uname -m)"

--- a/build_files/post/dual-sign.sh
+++ b/build_files/post/dual-sign.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 if [[ "${DUAL_SIGN}" != "true" ]]; then
     echo "Not Dual Signing..."

--- a/build_files/prep/build-prep.sh
+++ b/build_files/prep/build-prep.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ### PREPARE REPOS
 # enable RPMs with alternatives to create them in this image build

--- a/build_files/prep/dual-sign-check.sh
+++ b/build_files/prep/dual-sign-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 KERNEL="$1"
 module="$2"

--- a/build_files/test/check-signatures.sh
+++ b/build_files/test/check-signatures.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 #shellcheck disable=SC1091
 source /tmp/info.sh

--- a/build_files/test/test-prep.sh
+++ b/build_files/test/test-prep.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 pushd /tmp/kernel_cache
 KERNEL_VERSION=$(find "$KERNEL_NAME"-*.rpm | grep "$(uname -m)" | grep -P "$KERNEL_NAME-\d+\.\d+\.\d+-\w+.*$(rpm -E '%{dist}')" | sed -E "s/$KERNEL_NAME-//;s/\.rpm//")

--- a/build_files/zfs/build-kmod-zfs.sh
+++ b/build_files/zfs/build-kmod-zfs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 # allow pinning to a specific release series (eg, 2.0.x or 2.1.x)

--- a/build_files/zfs/build-ublue-os-ucore-addons.sh
+++ b/build_files/zfs/build-ublue-os-ucore-addons.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 ### BUILD UCORE-ADDONS RPM
 install -D /etc/pki/akmods/certs/public_key.der /tmp/ublue-os-ucore-addons/rpmbuild/SOURCES/public_key.der

--- a/build_files/zfs/dual-sign-zfs.sh
+++ b/build_files/zfs/dual-sign-zfs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 if [[ "${DUAL_SIGN}" != "true" ]]; then
     echo "Not Dual Signing..."

--- a/fetch-kernel.sh
+++ b/fetch-kernel.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set "${CI:+-x}" -euo pipefail
+set ${CI:+-x} -euo pipefail
 
 # ensures we pass a known dir for volume mount of output rpm files
 KCWD=/tmp/kernel-cache


### PR DESCRIPTION
There's a lot of:

`set "${CI+-x}" -euo pipefail`

This works fine when CI is set, however when CI is not set this resolves to:

`set "" -euo pipefail`

Which, since `""` isn't a valid shell option, causes bash to set  `$@` to `"", "-euo", "pipefail"`.  Which is definitely not the intended effect.  This is harmless in a lot of places if $@ isn't used, but it's causing failures in at least one place when build_files/prep/dual-sign-check.sh is called with arguments and proceeds to do weird stuff from the improper set.

Fix all of these by removing the quotes, which will eval properly in both cases.