### PR TITLE
feat: add nct6687d to extra build via terra

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -102,6 +102,7 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
     bash <<'RUNEOF'
 set "${CI+-x}" -euo pipefail
 /tmp/build-kmod-gcadapter_oc.sh || echo "SKIPPED: gcadapter_oc"
+/tmp/build-kmod-nct6687d.sh || echo "SKIPPED: nct6687d"
 /tmp/build-kmod-zenergy.sh || echo "SKIPPED: zenergy"
 /tmp/build-kmod-ryzen-smu.sh || echo "SKIPPED: ryzen-smu"
 /tmp/build-kmod-evdi.sh || echo "SKIPPED: evdi"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The `nvidia` and `nvidia-open` images contains
 | extra | [hid-fanatecff](https://github.com/gotzl/hid-fanatecff) | Fanatec wheel base force feedback | [Terra](https://github.com/terrapkg/packages) |
 | extra | [hid-tmff2](https://github.com/Kimplul/hid-tmff2) | Thrustmaster T300RS, T248, TX, T128, T598, T-GT II, TS-XW force feedback | [Terra](https://github.com/terrapkg/packages) |
 | extra | [kvmfr](https://github.com/gnif/looking-glass) | KVM framebuffer relay kernel module for use with Looking Glass | [![badge](https://copr.fedorainfracloud.org/coprs/hikariknight/looking-glass-kvmfr/package/kvmfr-kmod/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/hikariknight/looking-glass-kvmfr/package/kvmfr-kmod) |
+| extra | [nct6687d](https://github.com/Fred78290/nct6687d) | Linux kernel module for Nuvoton NCT6687-R found on AMD B550 chipset motherboards | [Terra](https://github.com/terrapkg/packages) |
 | extra | [new-lg4ff](https://github.com/berarma/new-lg4ff) | Logitech force feedback wheels | [Terra](https://github.com/terrapkg/packages) |
 | extra | [ryzen-smu](https://github.com/leogx9r/ryzen_smu) | AMD Ryzen SMU (System Management Unit) driver | [![badge](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/ryzen-smu-kmod/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/ryzen-smu-kmod) |
 | extra | [sc0710](https://github.com/Nakildias/sc0710) | Elgato 4K60 Pro MK.2 / 4K Pro capture card driver | [Terra](https://github.com/terrapkg/packages) |

--- a/build_files/extra/build-kmod-nct6687d.sh
+++ b/build_files/extra/build-kmod-nct6687d.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+
+set "${CI:+-x}" -euo pipefail
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/terra.repo /etc/yum.repos.d/
+curl -LsSf -o /etc/pki/rpm-gpg/RPM-GPG-KEY-terra"${RELEASE}" \
+    "https://raw.githubusercontent.com/terrapkg/packages/f${RELEASE}/anda/terra/gpg-keys/RPM-GPG-KEY-terra${RELEASE}"
+rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-terra"${RELEASE}"
+
+### BUILD nct6687d (succeed or fail-fast with debug output)
+dnf install -y \
+    akmod-nct6687d-*.fc"${RELEASE}"."${ARCH}"
+akmods --force --kernels "${KERNEL}" --kmod nct6687d
+modinfo /usr/lib/modules/"${KERNEL}"/extra/nct6687d/nct6687.ko.xz > /dev/null \
+|| (find /var/cache/akmods/nct6687d/ -name \*.log -print -exec cat {} \; && exit 1)
+
+mkdir -p /var/cache/rpms/extra
+dnf download --destdir /var/cache/rpms/extra \
+    nct6687d \
+    nct6687d-akmod-modules
+
+rm -f /var/cache/rpms/extra/*.src.rpm
+
+rm -f /etc/yum.repos.d/terra.repo


### PR DESCRIPTION
This adds the nct6687d driver to the extra build stream, sourcing it from the Terra repository.

Related issues:
- https://github.com/ublue-os/akmods/issues/504
- https://github.com/ublue-os/bazzite/issues/4776
- https://github.com/ublue-os/bazzite/issues/3813