### PR TITLE
chore: remove gnome-shell-extension-supergfxctl-gex

### DIFF
--- a/build_files/nvidia/nvidia-install.sh
+++ b/build_files/nvidia/nvidia-install.sh
@@ -64,7 +64,6 @@ if [[ "${IMAGE_NAME}" == "kinoite" ]]; then
     )
 elif [[ "${IMAGE_NAME}" == "silverblue" ]]; then
     VARIANT_PKGS=(
-        gnome-shell-extension-supergfxctl-gex
         supergfxctl
     )
 else


### PR DESCRIPTION
Resolves: https://github.com/ublue-os/bazzite/issues/3926

Both extensions had been removed in commits:

- `gnome-shell-extension-supergfxctl-gex` https://github.com/ublue-os/bazzite/commit/39a3180e4d453e9b6497268f38f5669cc0c4151b

- `supergfxctl-plasmoid supergfxctl` https://github.com/ublue-os/bazzite/commit/dc63268e24ff657c2aca84b818e54eb8bc31039e 

prior to commit: https://github.com/ublue-os/bazzite/commit/6a419847e6f33fda2cb3afaa26a5cbb9ed774bd2 which switched bazzite to using akmods. It seems like this was a simple copy paste error and the extension should not have been readded.