### PR TITLE
feat(extra): add nct6687d akmod via Terra

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -102,6 +102,7 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
     bash <<'RUNEOF'
 set ${CI+-x} -euo pipefail
 /tmp/build-kmod-gcadapter_oc.sh || echo "SKIPPED: gcadapter_oc"
+/tmp/build-kmod-nct6687d.sh || echo "SKIPPED: nct6687d"
 /tmp/build-kmod-zenergy.sh || echo "SKIPPED: zenergy"
 /tmp/build-kmod-ryzen-smu.sh || echo "SKIPPED: ryzen-smu"
 /tmp/build-kmod-evdi.sh || echo "SKIPPED: evdi"

--- a/Containerfile.in
+++ b/Containerfile.in
@@ -104,6 +104,7 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
     bash <<'RUNEOF'
 set ${CI+-x} -euo pipefail
 /tmp/build-kmod-gcadapter_oc.sh || echo "SKIPPED: gcadapter_oc"
+/tmp/build-kmod-nct6687d.sh || echo "SKIPPED: nct6687d"
 /tmp/build-kmod-zenergy.sh || echo "SKIPPED: zenergy"
 /tmp/build-kmod-ryzen-smu.sh || echo "SKIPPED: ryzen-smu"
 /tmp/build-kmod-evdi.sh || echo "SKIPPED: evdi"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The `nvidia` and `nvidia-open` images contains
 | extra | [hid-fanatecff](https://github.com/gotzl/hid-fanatecff) | Fanatec wheel base force feedback | [Terra](https://github.com/terrapkg/packages) |
 | extra | [hid-tmff2](https://github.com/Kimplul/hid-tmff2) | Thrustmaster T300RS, T248, TX, T128, T598, T-GT II, TS-XW force feedback | [Terra](https://github.com/terrapkg/packages) |
 | extra | [kvmfr](https://github.com/gnif/looking-glass) | KVM framebuffer relay kernel module for use with Looking Glass | [![badge](https://copr.fedorainfracloud.org/coprs/hikariknight/looking-glass-kvmfr/package/kvmfr-kmod/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/hikariknight/looking-glass-kvmfr/package/kvmfr-kmod) |
+| extra | [nct6687d](https://github.com/Fred78290/nct6687d) | Linux kernel module for Nuvoton NCT6687D/NCT6687-R motherboard fan control | [Terra](https://github.com/terrapkg/packages) |
 | extra | [new-lg4ff](https://github.com/berarma/new-lg4ff) | Logitech force feedback wheels | [Terra](https://github.com/terrapkg/packages) |
 | extra | [ryzen-smu](https://github.com/leogx9r/ryzen_smu) | AMD Ryzen SMU (System Management Unit) driver | [![badge](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/ryzen-smu-kmod/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/ublue-os/akmods/package/ryzen-smu-kmod) |
 | extra | [sc0710](https://github.com/Nakildias/sc0710) | Elgato 4K60 Pro MK.2 / 4K Pro capture card driver | [Terra](https://github.com/terrapkg/packages) |

--- a/build_files/extra/build-kmod-nct6687d.sh
+++ b/build_files/extra/build-kmod-nct6687d.sh
@@ -28,8 +28,7 @@ find /var/cache/akmods/nct6687d/ -type f -name "kmod-nct6687d-${KERNEL}-*.rpm" |
 
 mkdir -p /var/cache/rpms/extra
 dnf download --destdir /var/cache/rpms/extra \
-    nct6687d \
-    nct6687d-akmod-modules
+    nct6687d
 
 rm -f /var/cache/rpms/extra/*.src.rpm
 rm -f /etc/yum.repos.d/terra.repo

--- a/build_files/extra/build-kmod-nct6687d.sh
+++ b/build_files/extra/build-kmod-nct6687d.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/bash
+set "${CI:+-x}" -euo pipefail
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/terra.repo /etc/yum.repos.d/
+curl -LsSf -o /etc/pki/rpm-gpg/RPM-GPG-KEY-terra"${RELEASE}" \
+    "https://raw.githubusercontent.com/terrapkg/packages/f${RELEASE}/anda/terra/gpg-keys/RPM-GPG-KEY-terra${RELEASE}"
+rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-terra"${RELEASE}"
+
+### BUILD nct6687d (succeed or fail-fast with debug output)
+dnf install -y \
+    akmod-nct6687d-*.fc"${RELEASE}"."${ARCH}"
+
+akmods --force --kernels "${KERNEL}" --kmod nct6687d
+
+MODULE="/usr/lib/modules/${KERNEL}/extra/nct6687d/nct6687.ko.xz"
+modinfo "${MODULE}" > /dev/null \
+|| (find /var/cache/akmods/nct6687d/ -name \*.log -print -exec cat {} \; && exit 1)
+
+find /var/cache/akmods/nct6687d/ -type f -name "kmod-nct6687d-${KERNEL}-*.rpm" | grep -q . \
+|| (echo "ERROR: expected kmod-nct6687d-${KERNEL}-*.rpm was not produced" >&2; \
+    find /var/cache/akmods/nct6687d/ -maxdepth 5 -type f -print >&2; \
+    find /var/cache/akmods/nct6687d/ -name \*.log -print -exec cat {} \; ; \
+    exit 1)
+
+mkdir -p /var/cache/rpms/extra
+dnf download --destdir /var/cache/rpms/extra \
+    nct6687d \
+    nct6687d-akmod-modules
+
+rm -f /var/cache/rpms/extra/*.src.rpm
+rm -f /etc/yum.repos.d/terra.repo


### PR DESCRIPTION
## Description

Re-adds `nct6687d` to the `extra` akmods build stream via Terra.

Changes:

- Adds `build_files/extra/build-kmod-nct6687d.sh`
- Calls it from the existing `EXTRA` build block in `Containerfile.in`
- Adds `nct6687d` to the README `extra` module table

This is intended to preserve the approach from #511.

## Type of Change

- [ ] Bug fix
- [x] New feature / hardware enablement
- [x] Documentation update
- [ ] Code refactoring
- [x] Build improvement

## Testing Done

- [x] `bash -n build_files/extra/build-kmod-nct6687d.sh`
- [x] `git diff --check`
- [x] PR GitHub Actions build

The driver was also validated separately on affected hardware by manually building/signing/loading the current Terra `nct6687d` module. Once loaded, it exposed `/sys/devices/platform/nct6687.2592` with writable PWM files, and CoolerControl successfully applied fan profiles.

Manual testing details: https://github.com/ublue-os/bazzite/issues/4776#issuecomment-4426867891

## Differences from #511

Intentional differences from #511:

- Adds an explicit check that `kmod-nct6687d-${KERNEL}-*.rpm` is produced under `/var/cache/akmods/nct6687d/`
- Uses a broader README description for NCT6687D/NCT6687-R motherboard fan control

Everything else is intended to stay close to the #511 approach.

## CI notes

The unrelated ZFS CI failures are tracked separately in #523.

## Related Issues / PRs

- Replaces/retries: #511
- Revert that removed #511: #519
- Related issue: #504
- Related Bazzite issues: ublue-os/bazzite#4776, ublue-os/bazzite#3813, ublue-os/bazzite#4688