### PR TITLE
fix(nvidia): ensure nvidia-driver-selinux is installed for 32-bit

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -24,6 +24,10 @@ COPY files/usr/lib/systemd/system/ublue-nvctk-cdi.service /tmp/ublue-os-nvidia-a
 COPY files/usr/lib/systemd/system/ublue-nvctk-cdi.service /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/ublue-nvctk-cdi.service
 COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/70-ublue-nvctk-cdi.preset
 COPY files/usr/lib/systemd/system-preset/70-ublue-nvctk-cdi.preset /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/70-ublue-nvctk-cdi.preset
+COPY files/usr/lib/systemd/system/ublue-nvidia-selinux.service /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/ublue-nvidia-selinux.service
+COPY files/usr/lib/systemd/system/ublue-nvidia-selinux.service /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/ublue-nvidia-selinux.service
+COPY files/usr/lib/systemd/system-preset/70-ublue-nvidia-selinux.preset /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/70-ublue-nvidia-selinux.preset
+COPY files/usr/lib/systemd/system-preset/70-ublue-nvidia-selinux.preset /tmp/ublue-os-ucore-nvidia/rpmbuild/SOURCES/70-ublue-nvidia-selinux.preset
 COPY files/etc/udev/rules.d/60-nvidia-extra-devices-pm.rules /tmp/ublue-os-nvidia-addons/rpmbuild/SOURCES/60-nvidia-extra-devices-pm.rules
 
 #ifndef CENTOS

--- a/build_files/nvidia/download-nvidia-rpms.sh
+++ b/build_files/nvidia/download-nvidia-rpms.sh
@@ -64,6 +64,7 @@ NVIDIA_RPMS+=(
     "nvidia-driver-cuda-libs"
     "nvidia-driver-libs"
     "nvidia-kmod-common"
+    "nvidia-driver-selinux"
     "nvidia-libXNVCtrl"
     "nvidia-modprobe"
     "nvidia-persistenced"

--- a/build_files/nvidia/download-nvidia-rpms.sh
+++ b/build_files/nvidia/download-nvidia-rpms.sh
@@ -64,7 +64,6 @@ NVIDIA_RPMS+=(
     "nvidia-driver-cuda-libs"
     "nvidia-driver-libs"
     "nvidia-kmod-common"
-    "nvidia-driver-selinux"
     "nvidia-libXNVCtrl"
     "nvidia-modprobe"
     "nvidia-persistenced"

--- a/build_files/nvidia/nvidia-install.sh
+++ b/build_files/nvidia/nvidia-install.sh
@@ -108,10 +108,10 @@ systemctl enable ublue-nvctk-cdi.service
 systemctl enable ublue-nvidia-selinux.service
 semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
 
-# nvidia-driver-selinux is explicitly listed above so it is pulled into the main
-# transaction (the weak conditional on nvidia-kmod-common only + no 32-bit deps
-# + March 2026 weakening made it unreliable). The 610 driver-common split
-# exacerbated 32-bit labeling issues on newer kernels.
+# nvidia-driver-selinux is pulled at runtime (when the nvidia repo is enabled)
+# because it has only a weak/conditional dependency upstream. Explicitly listing
+# it ensures the policy is installed even after the March 2026 weakening of the
+# dep and the 610 driver-common packaging changes that affected 32-bit labeling.
 # See: https://github.com/negativo17/nvidia-driver/issues/200
 
 # Load main driver SELinux policy + relabel nvidia files so 32-bit libs get correct contexts.

--- a/build_files/nvidia/nvidia-install.sh
+++ b/build_files/nvidia/nvidia-install.sh
@@ -76,6 +76,7 @@ NVIDIA_RPMS=(
     nvidia-container-toolkit
     egl-wayland
     libva-nvidia-driver
+    nvidia-driver-selinux
     "${VARIANT_PKGS[@]}"
     "${AKMODNV_PATH}"/kmods/kmod-nvidia-"${KERNEL_VERSION}"-"${NVIDIA_AKMOD_VERSION}"."${DIST_ARCH}".rpm
 )
@@ -104,7 +105,25 @@ dnf5 config-manager setopt fedora-nvidia*.enabled=0 nvidia-container-toolkit.ena
 dnf5 -y copr disable ublue-os/staging
 
 systemctl enable ublue-nvctk-cdi.service
+systemctl enable ublue-nvidia-selinux.service
 semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
+
+# nvidia-driver-selinux is explicitly listed above so it is pulled into the main
+# transaction (the weak conditional on nvidia-kmod-common only + no 32-bit deps
+# + March 2026 weakening made it unreliable). The 610 driver-common split
+# exacerbated 32-bit labeling issues on newer kernels.
+# See: https://github.com/negativo17/nvidia-driver/issues/200
+
+# Load main driver SELinux policy + relabel nvidia files so 32-bit libs get correct contexts.
+if [[ -f /usr/share/selinux/packages/targeted/nvidia-driver.pp.bz2 ]]; then
+    semodule -i /usr/share/selinux/packages/targeted/nvidia-driver.pp.bz2 || true
+fi
+restorecon -RFv \
+    /usr/lib*/libnvidia* \
+    /usr/lib*/nvidia* \
+    /etc/modprobe.d/nvidia.conf \
+    /usr/lib/dracut/dracut.conf.d/99-nvidia.conf \
+    2>/dev/null || true
 
 # we must force driver load to fix black screen on boot for nvidia desktops
 sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf

--- a/build_files/nvidia/ublue-os-nvidia-addons/ublue-os-nvidia-addons.spec
+++ b/build_files/nvidia/ublue-os-nvidia-addons/ublue-os-nvidia-addons.spec
@@ -18,6 +18,8 @@ Source6:        60-nvidia-extra-devices-pm.rules
 Source7:        negativo17-epel-nvidia.repo
 Source8:        negativo17-epel-nvidia-lts.repo
 Source9:        negativo17-fedora-nvidia-lts.repo
+Source10:       ublue-nvidia-selinux.service
+Source11:       70-ublue-nvidia-selinux.preset
 
 %description
 Adds various runtime files for nvidia support.
@@ -48,10 +50,14 @@ install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.r
 install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp
 install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service
 install -Dm0644 %{SOURCE3} %{buildroot}%{_presetdir}/70-ublue-nvctk-cdi.preset
+install -Dm0644 %{SOURCE10} %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvidia-selinux.service
+install -Dm0644 %{SOURCE11} %{buildroot}%{_presetdir}/70-ublue-nvidia-selinux.preset
 sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/nvidia-container-toolkit.repo
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_datadir}/selinux/packages/nvidia-container.pp             %{buildroot}%{_datadir}/selinux/packages/nvidia-container.pp
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.service                          %{buildroot}%{_unitdir}/ublue-nvctk-cdi.service
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvidia-selinux.service                     %{buildroot}%{_unitdir}/ublue-nvidia-selinux.service
+install -Dm0644 %{buildroot}%{_presetdir}/70-ublue-nvidia-selinux.preset                                       %{buildroot}%{_presetdir}/70-ublue-nvidia-selinux.preset
 
 %files
 %if 0%{?rhel}
@@ -73,6 +79,9 @@ install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_unitdir}/ublue-nvctk-cdi.ser
 %attr(0644,root,root) %{_datadir}/selinux/packages/nvidia-container.pp
 %attr(0644,root,root) %{_unitdir}/ublue-nvctk-cdi.service
 %attr(0644,root,root) %{_presetdir}/70-ublue-nvctk-cdi.preset
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_unitdir}/ublue-nvidia-selinux.service
+%attr(0644,root,root) %{_unitdir}/ublue-nvidia-selinux.service
+%attr(0644,root,root) %{_presetdir}/70-ublue-nvidia-selinux.preset
 
 %changelog
 * Mon Dec 8 2025 Benjamin Sherman <benjamin@holyarmy.org> - 0.14

--- a/files/usr/lib/systemd/system-preset/70-ublue-nvidia-selinux.preset
+++ b/files/usr/lib/systemd/system-preset/70-ublue-nvidia-selinux.preset
@@ -1,0 +1,1 @@
+enable ublue-nvidia-selinux.service

--- a/files/usr/lib/systemd/system/ublue-nvidia-selinux.service
+++ b/files/usr/lib/systemd/system/ublue-nvidia-selinux.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=Load NVIDIA proprietary driver SELinux policy
+Documentation=https://github.com/ublue-os/akmods
+After=local-fs.target selinux-autorelabel-mark.service
+Before=graphical.target multi-user.target
+ConditionPathExists=/usr/share/selinux/packages/targeted/nvidia-driver.pp.bz2
+# Only run if SELinux is enabled
+ConditionSecurity=selinux
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+
+# NOTE on "run only once" behavior:
+#
+# With RemainAfterExit=yes, this oneshot will execute on the first boot after the
+# unit is enabled (or after a rebase that changes the unit or its dependencies),
+# then transition to "active (exited)" and will not re-run on subsequent boots
+# in the same deployment.
+#
+# We deliberately do NOT add extra "run exactly once ever" logic (e.g. a stamp
+# file in /var that prevents future executions). Reasons:
+#
+# 1. The work (semodule -i + restorecon on /etc paths) is cheap and idempotent.
+# 2. After a user rebases to a new image (the main reason this service exists),
+#    we *want* it to re-execute so the updated nvidia-driver.pp policy is loaded
+#    and any new overlay files get correct labels.
+# 3. On bootc/ostree systems, a rebase + reboot is the signal that "something
+#    important may have changed in the base image". Relying only on
+#    RemainAfterExit=yes + the natural reboot boundary is sufficient and robust.
+#
+# If you ever need to force it to re-run on the current boot:
+#   systemctl restart ublue-nvidia-selinux.service
+
+ExecStart=/bin/sh -c '\
+    if command -v semodule >/dev/null; then \
+        semodule -i /usr/share/selinux/packages/targeted/nvidia-driver.pp.bz2 2>/dev/null || true; \
+    fi; \
+    if command -v restorecon >/dev/null; then \
+        restorecon -RFv \
+            /etc/modprobe.d/nvidia.conf \
+            /usr/lib/dracut/dracut.conf.d/99-nvidia.conf \
+            2>/dev/null || true; \
+    fi'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The nvidia-driver-selinux package was previously only pulled in via a weak conditional dependency on nvidia-kmod-common. None of the 32-bit packages declared any dependency on it, and the conditional was further weakened in early 2026. This left 32-bit NVIDIA libraries without proper SELinux labeling on enforcing systems, especially after the 610 driver-common packaging changes.

This was particularly problematic on bootc/ostree systems (Bazzite, Bluefin, etc.) where /usr is read-only.

Changes:
- Explicitly include nvidia-driver-selinux in the cached RPMs and main install transaction.
- Perform build-time semodule load and restorecon so labels are baked into new images.
- Add a new oneshot service (ublue-nvidia-selinux.service) that loads the driver SELinux policy and performs safe relabeling of overlay paths after rebases/updates.
- Ship the service and preset via ublue-os-nvidia-addons.

The runtime service is intentionally allowed to re-run after image updates (it is idempotent) so that policy and labeling stay correct after users rebase to a fixed image.

Related upstream issue: https://github.com/negativo17/nvidia-driver/issues/200

