### PR TITLE
fix(nvidia): match driver-common by version only

### DIFF
--- a/build_files/nvidia/download-nvidia-rpms.sh
+++ b/build_files/nvidia/download-nvidia-rpms.sh
@@ -30,13 +30,13 @@ else
 fi
 
 NVIDIA_DRIVER_COMMON_PKGS=()
-if dnf repoquery --qf '%{EPOCH}:%{VERSION}-%{RELEASE}\n' nvidia-driver-common | grep -qxF "${DRIVER_EVR}"; then
+if dnf repoquery --qf '%{VERSION}\n' nvidia-driver-common | grep -qxF "${DRIVER_VERSION}"; then
     echo "Using nvidia-driver-common for NVIDIA ${DRIVER_VERSION}"
     NVIDIA_DRIVER_COMMON_PKGS+=(
         "nvidia-driver-common"
     )
     if [[ "${ARCH}" = "x86_64" && ! "${KERNEL_FLAVOR}" =~ "centos" ]] && \
-        dnf repoquery --qf '%{EPOCH}:%{VERSION}-%{RELEASE}\n' nvidia-driver-common.i686 | grep -qxF "${DRIVER_EVR}"; then
+        dnf repoquery --qf '%{VERSION}\n' nvidia-driver-common.i686 | grep -qxF "${DRIVER_VERSION}"; then
         NVIDIA_EXTRA_PKGS+=(
             "nvidia-driver-common.i686"
         )


### PR DESCRIPTION
The check  in #535 to handle the `nvidia-driver-common` package split compared the full `EPOCH:VERSION-RELEASE` of `akmod-nvidia`. This was failing because `akmod-nvidia` and `nvidia-driver-common` can have different release numbers (e.g. 610.43.02-1 vs 610.43.02-2). This seems to be what is responsible for the recent workflow failures.

This PR fixes it by comparing only the version (the middle part) instead of also matching the epoch and release.

Analysis performed by Sonnet 4.6. It looks correct, but the CI should tell the story.