### PR TITLE
feat: readd vhba to support CDEmu again in ublue images

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -33,6 +33,8 @@ ADD https://negativo17.org/repos/fedora-multimedia.repo \
     /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/negativo17-fedora-multimedia.repo
 ADD https://raw.githubusercontent.com/terrapkg/packages/f${VERSION}/anda/terra/release/terra.repo \
     /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/terra.repo
+ADD https://copr.fedorainfracloud.org/coprs/rok/cdemu/repo/fedora-${VERSION}/rok-cdemu-fedora-${VERSION}.repo \
+    /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_rok-cdemu.repo
 ADD https://raw.githubusercontent.com/terrapkg/packages/f${VERSION}/anda/terra/gpg-keys/RPM-GPG-KEY-terra${VERSION} \
     /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/RPM-GPG-KEY-terra${VERSION}
 #endif
@@ -88,6 +90,7 @@ RUN --mount=type=cache,dst=/var/cache/dnf \
 /tmp/build-kmod-framework-laptop.sh
 /tmp/build-kmod-openrazer.sh
 /tmp/build-kmod-v4l2loopback.sh
+/tmp/build-kmod-vhba.sh
 /tmp/build-kmod-wl.sh
 /tmp/build-kmod-xpadneo.sh
 /tmp/build-kmod-xone.sh

--- a/build_files/common/build-kmod-vhba.sh
+++ b/build_files/common/build-kmod-vhba.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/bash
+
+set "${CI:+-x}" -euo pipefail
+
+ARCH="$(rpm -E '%_arch')"
+KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
+RELEASE="$(rpm -E '%fedora')"
+
+cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_rok-cdemu.repo /etc/yum.repos.d/
+
+### BUILD vhba (succeed or fail-fast with debug output)
+dnf install -y \
+    akmod-vhba-*.fc"${RELEASE}"."${ARCH}"
+akmods --force --kernels "${KERNEL}" --kmod vhba
+modinfo /usr/lib/modules/"${KERNEL}"/extra/vhba/vhba.ko.xz > /dev/null \
+|| (find /var/cache/akmods/vhba/ -name \*.log -print -exec cat {} \; && exit 1)
+
+rm -f /etc/yum.repos.d/_copr_rok-cdemu.repo

--- a/build_files/common/build-kmod-vhba.sh
+++ b/build_files/common/build-kmod-vhba.sh
@@ -15,4 +15,10 @@ akmods --force --kernels "${KERNEL}" --kmod vhba
 modinfo /usr/lib/modules/"${KERNEL}"/extra/vhba/vhba.ko.xz > /dev/null \
 || (find /var/cache/akmods/vhba/ -name \*.log -print -exec cat {} \; && exit 1)
 
+mkdir -p /var/cache/rpms/common
+dnf download --destdir /var/cache/rpms/common \
+    vhba-kmod-common
+
+rm -f /var/cache/rpms/common/*.src.rpm
+
 rm -f /etc/yum.repos.d/_copr_rok-cdemu.repo

--- a/build_files/common/ublue-os-akmods-addons/ublue-os-akmods-addons.spec
+++ b/build_files/common/ublue-os-akmods-addons/ublue-os-akmods-addons.spec
@@ -1,5 +1,5 @@
 Name:           ublue-os-akmods-addons
-Version:        0.7
+Version:        0.8
 Release:        1%{?dist}
 Summary:        Signing key and repos for ublue os akmods
 
@@ -12,6 +12,7 @@ Supplements:    mokutil policycoreutils
 Source0:        public_key.der
 Source1:        _copr_ublue-os-akmods.repo
 Source2:        negativo17-fedora-multimedia.repo
+Source3:        _copr_rok-cdemu.repo
 
 %description
 Adds the signing key for importing with mokutil to enable secure boot for kernel modules and repo files required to install akmod dependencies.
@@ -25,22 +26,30 @@ Adds the signing key for importing with mokutil to enable secure boot for kernel
 install -Dm0644 %{SOURCE0} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
 install -Dm0644 %{SOURCE1} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo
 install -Dm0644 %{SOURCE2} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-multimedia.repo
+install -Dm0644 %{SOURCE3} %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_rok-cdemu.repo
 
 sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-multimedia.repo
+sed -i 's@enabled=1@enabled=0@g' %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_rok-cdemu.repo
 
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der            %{buildroot}%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo    %{buildroot}%{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo
 install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-multimedia.repo     %{buildroot}%{_sysconfdir}/yum.repos.d/negativo17-fedora-multimedia.repo
+install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_rok-cdemu.repo        %{buildroot}%{_sysconfdir}/yum.repos.d/_copr_rok-cdemu.repo
 
 %files
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo
 %attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/negativo17-fedora-multimedia.repo
+%attr(0644,root,root) %{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_copr_rok-cdemu.repo
 %attr(0644,root,root) %{_sysconfdir}/pki/akmods/certs/akmods-ublue.der
 %attr(0644,root,root) %{_sysconfdir}/yum.repos.d/_copr_ublue-os-akmods.repo
 %attr(0644,root,root) %{_sysconfdir}/yum.repos.d/negativo17-fedora-multimedia.repo
+%attr(0644,root,root) %{_sysconfdir}/yum.repos.d/_copr_rok-cdemu.repo
 
 %changelog
+* Mon Aug 31 2026 Marco Rodolfi <marco.rodolfi@tuta.io> - 0.8
+- Revert rok/cdemu copr repo removal for vhba kmod support on unified kernel package
+
 * Mon Apr 23 2024 Kyle Gospodnetich <me@kylegospodneti.ch> - 0.6
 - Remove unneeded repositories
 

--- a/build_files/common/ublue-os-akmods-addons/ublue-os-akmods-addons.spec
+++ b/build_files/common/ublue-os-akmods-addons/ublue-os-akmods-addons.spec
@@ -47,7 +47,7 @@ install -Dm0644 %{buildroot}%{_datadir}/ublue-os/%{_sysconfdir}/yum.repos.d/_cop
 %attr(0644,root,root) %{_sysconfdir}/yum.repos.d/_copr_rok-cdemu.repo
 
 %changelog
-* Mon Aug 31 2026 Marco Rodolfi <marco.rodolfi@tuta.io> - 0.8
+* Mon Jul 31 2026 Marco Rodolfi <marco.rodolfi@tuta.io> - 0.8
 - Revert rok/cdemu copr repo removal for vhba kmod support on unified kernel package
 
 * Mon Apr 23 2024 Kyle Gospodnetich <me@kylegospodneti.ch> - 0.6


### PR DESCRIPTION
Partial revert and readaptation of #165. This was originally removed in #414 since Bazzite was using a forked kernel and it didn't need an akmod build anymore ([reference](https://github.com/ublue-os/akmods/pull/414#pullrequestreview-3407574496)). However after Bazzite moved to the new OCG Kernel, installing vhba now causes a failure during install with:
```
marco@DeckDiMarco /v/h/marco [1]> sudo rpm-ostree install vhba-kmod
[sudo] password di marco: 
Checking out tree e8d116a... done
Enabled rpm-md repositories: updates fedora copr:copr.fedorainfracloud.org:rok:cdemu copr:copr.fedorainfracloud.org:rodoma92:kde-cdemu-manager copr:copr.fedorainfracloud.org:faugus:faugus-launcher updates-archive
Importing rpm-md... done
rpm-md repo 'updates' (cached); generated: 2026-07-31T01:09:30Z solvables: 31292
rpm-md repo 'fedora' (cached); generated: 2025-10-23T03:37:20Z solvables: 77664
rpm-md repo 'copr:copr.fedorainfracloud.org:rok:cdemu' (cached); generated: 2026-06-08T14:39:29Z solvables: 28
rpm-md repo 'copr:copr.fedorainfracloud.org:rodoma92:kde-cdemu-manager' (cached); generated: 2025-08-13T12:39:45Z solvables: 8
rpm-md repo 'copr:copr.fedorainfracloud.org:faugus:faugus-launcher' (cached); generated: 2026-07-30T12:51:15Z solvables: 10
rpm-md repo 'updates-archive' (cached); generated: 2026-07-30T07:21:40Z solvables: 65509
Resolving dependencies... done
Will download: 16 packages (1,1 MB)
Downloading from 'updates'... done
Downloading from 'copr:copr.fedorainfracloud.org:rok:cdemu'... done
Downloading from 'updates-archive'... done
Downloading from 'fedora'... done
Importing packages... done
Checking out packages... done
Running systemd-sysusers... done
Running pre scripts... done
Running post scripts... done
error: While applying overrides for pkg akmods: Could not find group 'akmods' in group file
```
This restores the previous working implementation, allowing me to recreate an automated installer for CDEmu in Bazzite.