### PR TITLE
fix(workflows): separate provenance from image signature discovery

### DIFF
--- a/.github/workflows/build-akmods-centos.yml
+++ b/.github/workflows/build-akmods-centos.yml
@@ -35,7 +35,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -53,7 +52,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -71,7 +69,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write

--- a/.github/workflows/build-akmods-coreos-stable.yml
+++ b/.github/workflows/build-akmods-coreos-stable.yml
@@ -35,7 +35,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -53,7 +52,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -71,7 +69,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -89,7 +86,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -134,7 +130,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -152,7 +147,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -170,7 +164,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -188,7 +181,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write

--- a/.github/workflows/build-akmods-coreos-testing.yml
+++ b/.github/workflows/build-akmods-coreos-testing.yml
@@ -35,7 +35,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -53,7 +52,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -71,7 +69,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -89,7 +86,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write

--- a/.github/workflows/build-akmods-longterm-6.18.yml
+++ b/.github/workflows/build-akmods-longterm-6.18.yml
@@ -35,7 +35,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -53,7 +52,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -71,7 +69,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write

--- a/.github/workflows/build-akmods-main.yml
+++ b/.github/workflows/build-akmods-main.yml
@@ -35,7 +35,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -53,7 +52,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -71,7 +69,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -116,7 +113,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -134,7 +130,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -152,7 +147,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write

--- a/.github/workflows/build-akmods-ogc.yml
+++ b/.github/workflows/build-akmods-ogc.yml
@@ -35,7 +35,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -53,7 +52,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -71,7 +69,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -89,7 +86,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -134,7 +130,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -152,7 +147,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -170,7 +164,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -188,7 +181,6 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -139,13 +139,16 @@ jobs:
     name: "Generate ${{ inputs.akmods_target != 'common' && format('akmods-{0}', inputs.akmods_target) || 'akmods' }}:${{ inputs.kernel_flavor }}-${{ inputs.version }} Manifest"
     runs-on: ubuntu-latest
     needs: [build-akmods]
+    outputs:
+      image_name: ${{ steps.digest.outputs.image_name }}
+      manifest: ${{ steps.digest.outputs.manifest }}
+      manifest_kernel: ${{ steps.digest.outputs.manifest_kernel }}
     container:
       image: "ghcr.io/ublue-os/devcontainer:latest@sha256:74af83ac3b3fa573bee61d6d2d5ea5ba59f92f44afc3833d57b05ace66eb98ca"
       options: "--privileged --volume /var/lib/containers:/var/lib/containers --security-opt seccomp=unconfined --security-opt label=disable --user 0:0"
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write
@@ -200,20 +203,13 @@ jobs:
 
           echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
 
-      - name: Login to GHCR for Attestation
-        if: contains(fromJson('["schedule", "workflow_dispatch", "merge_group"]'), github.event_name)
-        shell: bash
-        run: |
-          mkdir -p ~/.docker
-          podman login ghcr.io -u "${{ github.actor }}" -p "${{ github.token }}" --authfile ~/.docker/config.json
-
       - name: Attest Manifest Image
         if: contains(fromJson('["schedule", "workflow_dispatch", "merge_group"]'), github.event_name)
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/${{ steps.digest.outputs.image_name }}
           subject-digest: ${{ steps.digest.outputs.manifest }}
-          push-to-registry: true
+          push-to-registry: false
 
       - name: Attest Manifest Kernel Image
         if: contains(fromJson('["schedule", "workflow_dispatch", "merge_group"]'), github.event_name)
@@ -221,4 +217,131 @@ jobs:
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/${{ steps.digest.outputs.image_name }}
           subject-digest: ${{ steps.digest.outputs.manifest_kernel }}
-          push-to-registry: true
+          push-to-registry: false
+
+  verify-publication:
+    name: Verify Published Signatures and Provenance
+    runs-on: ubuntu-latest
+    needs: [manifest]
+    if: contains(fromJson('["schedule", "workflow_dispatch", "merge_group"]'), github.event_name)
+    permissions:
+      actions: read
+      attestations: write
+      contents: read
+      id-token: write
+      packages: read
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Skopeo
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes skopeo
+          command -v skopeo
+          skopeo --version
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: "v3.1.2"
+
+      - name: Verify Published Subjects
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/${{ needs.manifest.outputs.image_name }}
+          MANIFEST_DIGEST: ${{ needs.manifest.outputs.manifest }}
+          MANIFEST_KERNEL_DIGEST: ${{ needs.manifest.outputs.manifest_kernel }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cosign_version="$(cosign version)"
+          printf '%s\n' "$cosign_version"
+          [[ "$cosign_version" == *"GitVersion: v3.1.2"* ]]
+          command -v gh
+          gh --version
+
+          retry() {
+            local attempt
+            for attempt in 1 2 3 4 5; do
+              "$@" && return 0
+              if [[ "$attempt" -eq 5 ]]; then
+                return 1
+              fi
+              sleep $((attempt * 5))
+            done
+          }
+
+          verify_cosign() {
+            local image="$1"
+            retry cosign verify --key cosign.pub "$image"
+            retry cosign verify --new-bundle-format=false --key cosign.pub "$image"
+          }
+
+          policy_dir="$(mktemp -d)"
+          trap 'rm -rf "$policy_dir"' EXIT
+          cat > "$policy_dir/policy.json" <<'EOF'
+          {
+            "default": [{"type": "reject"}],
+            "transports": {
+              "docker": {
+                "ghcr.io/ublue-os/akmods": [{"type": "sigstoreSigned", "keyPath": "cosign.pub", "signedIdentity": {"type": "matchRepository"}}],
+                "ghcr.io/ublue-os/akmods-nvidia-lts": [{"type": "sigstoreSigned", "keyPath": "cosign.pub", "signedIdentity": {"type": "matchRepository"}}],
+                "ghcr.io/ublue-os/akmods-nvidia-open": [{"type": "sigstoreSigned", "keyPath": "cosign.pub", "signedIdentity": {"type": "matchRepository"}}],
+                "ghcr.io/ublue-os/akmods-zfs": [{"type": "sigstoreSigned", "keyPath": "cosign.pub", "signedIdentity": {"type": "matchRepository"}}],
+                "ghcr.io/ublue-os/akmods-extra": [{"type": "sigstoreSigned", "keyPath": "cosign.pub", "signedIdentity": {"type": "matchRepository"}}]
+              }
+            }
+          }
+          EOF
+          mkdir "$policy_dir/registries.d"
+          cat > "$policy_dir/registries.d/ghcr.yaml" <<'EOF'
+          docker:
+            ghcr.io:
+              use-sigstore-attachments: true
+          EOF
+
+          verify_policy() {
+            local image="$1"
+            local destination
+            destination="$(mktemp -d)"
+            retry skopeo copy --policy "$policy_dir/policy.json" --registries.d "$policy_dir/registries.d" "$image" "dir:$destination"
+            rm -rf "$destination"
+          }
+
+          manifest_tag="${{ inputs.kernel_flavor }}-${{ inputs.version }}"
+          subjects=(
+            "$IMAGE@$MANIFEST_DIGEST"
+            "$IMAGE@$MANIFEST_KERNEL_DIGEST"
+          )
+          for architecture in $(jq -r '.[]' <<'EOF'
+          ${{ inputs.architecture }}
+          EOF
+          ); do
+            release_digest="$(retry skopeo inspect --format '{{.Digest}}' "docker://$IMAGE:${manifest_tag}-${architecture}")"
+            subjects+=("$IMAGE@$release_digest")
+          done
+
+          for subject in "${subjects[@]}"; do
+            verify_cosign "$subject"
+            verify_policy "docker://$subject"
+          done
+
+          unsigned="quay.io/fedora/fedora-bootc@sha256:0cb32268d1a864801a6edc4032506f50f385d9f49c0b68a4eebecaaa555ecce6"
+          if cosign verify --key cosign.pub "$unsigned"; then
+            exit 1
+          fi
+          if cosign verify --new-bundle-format=false --key cosign.pub "$unsigned"; then
+            exit 1
+          fi
+          unsigned_destination="$(mktemp -d)"
+          if skopeo copy --policy "$policy_dir/policy.json" --registries.d "$policy_dir/registries.d" "docker://$unsigned" "dir:$unsigned_destination"; then
+            rm -rf "$unsigned_destination"
+            exit 1
+          fi
+          rm -rf "$unsigned_destination"
+
+          retry gh attestation verify "oci://$IMAGE@$MANIFEST_DIGEST" --repo ublue-os/akmods
+          retry gh attestation verify "oci://$IMAGE@$MANIFEST_KERNEL_DIGEST" --repo ublue-os/akmods

--- a/README.md
+++ b/README.md
@@ -117,9 +117,38 @@ For NVIDIA images, add something like this to your Containerfile, replacing `TAG
 
 ## Verification
 
-These images are signed with sisgstore's [cosign](https://docs.sigstore.dev/about/overview/). You can verify the signature by downloading the `cosign.pub` key from this repo and running the following command, replacing `KERNEL_FLAVOR` with whichever kernel you are using and `RELEASE` with either `40`, `41` or `42`:
+### Image Signatures
 
-    cosign verify --key cosign.pub ghcr.io/ublue-os/akmods:KERNEL_FLAVOR-RELEASE
+All architecture images and manifest indexes are signed by Podman with the shared Universal Blue static key. Prefer verifying immutable, digest-pinned subjects with Cosign v3.1.2:
+
+```bash
+cosign verify \
+  --key https://raw.githubusercontent.com/ublue-os/main/main/cosign.pub \
+  ghcr.io/ublue-os/akmods@sha256:DIGEST
+```
+
+For historical manifest digests with registry-attached GitHub provenance, use legacy bundle discovery:
+
+```bash
+cosign verify \
+  --new-bundle-format=false \
+  --key https://raw.githubusercontent.com/ublue-os/main/main/cosign.pub \
+  ghcr.io/ublue-os/akmods@sha256:DIGEST
+```
+
+The `ublue-os/main/cosign.pub` key is the Universal Blue image trust root. Mutable tags such as `main-44` or `coreos-stable-43` are convenient for discovery, but a digest is the preferred verification target.
+
+### Build Provenance
+
+GitHub build provenance is a separate trust decision from image signatures: it uses a short-lived GitHub OIDC certificate rather than the Universal Blue static key. Provenance currently covers the release and kernel-version manifest indexes, not architecture-only image digests.
+
+```bash
+gh attestation verify \
+  oci://ghcr.io/ublue-os/akmods@sha256:DIGEST \
+  --repo ublue-os/akmods
+```
+
+Provenance is stored in GitHub's attestations API. It is no longer published as a registry referrer, so registry provenance and GitHub linked-artifact storage records are not available for newly published digests.
 
 ## Local Building/Testing
 

--- a/workflow-templates/job.yaml.in
+++ b/workflow-templates/job.yaml.in
@@ -5,7 +5,6 @@
     permissions:
       actions: read
       attestations: write
-      artifact-metadata: write
       contents: read
       id-token: write
       packages: write


### PR DESCRIPTION
## Summary
- store manifest build provenance in GitHub Attestations without publishing GHCR referrers
- verify Podman signatures, containers/image policy enforcement, unsigned rejection, and manifest provenance after publication
- document independent image-signature and provenance verification paths

## Validation
- parsed reusable and generated workflow YAML
- validated the verification shell body with `bash -n`
- ran `git diff --check`

Closes: #546 