### PR TITLE
fix(zfs): backport upstream 7.1 and mmap fixes into 2.4.3

### DIFF
--- a/build_files/zfs/build-kmod-zfs.sh
+++ b/build_files/zfs/build-kmod-zfs.sh
@@ -64,6 +64,21 @@ fi
 tar -z -x --no-same-owner --no-same-permissions -f "zfs-${ZFS_VERSION}.tar.gz"
 
 cd "/tmp/zfs-${ZFS_VERSION}"
+
+# 2.4.3 predates both Linux 7.1 support (openzfs/zfs#18682) and the zfs_fillpage()
+# mmap underflow fix (openzfs/zfs#18715). Neither has been backported to
+# zfs-2.4-release, so carry them here for 2.4.3 only; later releases are expected
+# to ship them and must not be patched.
+if [[ "${ZFS_VERSION}" == "2.4.3" ]]; then
+    echo "zfs-${ZFS_VERSION} requires patches"
+    for patch in /tmp/patches/*.patch; do
+        echo "PATCH ${patch##*/}"
+        git apply "${patch}"
+    done
+else
+    echo "zfs-${ZFS_VERSION}: no patches required"
+fi
+
 # normalize timestamps so autotools doesn't complain about clock skew
 find . -exec touch -h -r "/tmp/zfs-${ZFS_VERSION}.tar.gz" {} + 2>/dev/null || true
 # ensure rpm spec depends on correct kernel-devel package, else build fails on kernel-longterm kernels

--- a/build_files/zfs/patches/0001-Linux-7.1-compat-META.patch
+++ b/build_files/zfs/patches/0001-Linux-7.1-compat-META.patch
@@ -1,0 +1,26 @@
+From a35e8d892628d01e50af23aee5ba501be426baf6 Mon Sep 17 00:00:00 2001
+From: Tony Hutter <hutter2@llnl.gov>
+Date: Wed, 17 Jun 2026 09:45:38 -0700
+Subject: [PATCH] Linux 7.1 compat: META (#18682)
+
+Update the META file to reflect compatibility with the 7.1
+kernel.
+
+Signed-off-by: Tony Hutter <hutter2@llnl.gov>
+Signed-off-by: Rob Norris <rob.norris@truenas.com>
+Reviewed-by: Chris Longros <chris.longros@gmail.com>
+---
+ META | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/META b/META
+index ab1b8955d245..3c688e54a11f 100644
+--- a/META
++++ b/META
+@@ -6,5 +6,5 @@ Release:       1
+ Release-Tags:  relext
+ License:       CDDL
+ Author:        OpenZFS
+-Linux-Maximum: 7.0
++Linux-Maximum: 7.1
+ Linux-Minimum: 4.18

--- a/build_files/zfs/patches/0002-linux-handle-mmap-read-beyond-file-size.patch
+++ b/build_files/zfs/patches/0002-linux-handle-mmap-read-beyond-file-size.patch
@@ -1,0 +1,59 @@
+From 223b8bc446851e5e796e5446ac24d03bbf468f43 Mon Sep 17 00:00:00 2001
+From: Brian Behlendorf <behlendorf1@llnl.gov>
+Date: Tue, 30 Jun 2026 10:49:14 -0700
+Subject: [PATCH] linux: handle mmap read beyond file size
+
+When performing a mmap read past the end of a file there is no data to
+read, so simply zero-fill the page and return success.  zfs_getpage()
+limits the range lock appropriately to cover the offset being read.
+
+Reported-by: Iliya Polihronov (@vnsavage) (Automattic)
+Reviewed-by: Alexander Motin <alexander.motin@TrueNAS.com>
+Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
+Closes #18715
+---
+ module/os/linux/zfs/zfs_vnops_os.c | 24 ++++++++++++++++++++----
+ 1 file changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/module/os/linux/zfs/zfs_vnops_os.c b/module/os/linux/zfs/zfs_vnops_os.c
+index 4ff9945c8956..90471213c2e0 100644
+--- a/module/os/linux/zfs/zfs_vnops_os.c
++++ b/module/os/linux/zfs/zfs_vnops_os.c
+@@ -4155,7 +4155,18 @@ zfs_fillpage(struct inode *ip, struct page *pp)
+ 	u_offset_t io_off = page_offset(pp);
+ 	size_t io_len = PAGE_SIZE;
+ 
+-	ASSERT3U(io_off, <, i_size);
++	/*
++	 * The page may be faulted in after the file has been truncated.
++	 * There is no data to read; just zero-fill the page.
++	 */
++	if (io_off >= i_size) {
++		void *zva = kmap(pp);
++		memset(zva, 0, PAGE_SIZE);
++		kunmap(pp);
++		ClearPageError(pp);
++		SetPageUptodate(pp);
++		return (0);
++	}
+ 
+ 	if (io_off + io_len > i_size)
+ 		io_len = i_size - io_off;
+@@ -4206,9 +4217,14 @@ zfs_getpage(struct inode *ip, struct page *pp)
+ 	if ((error = zfs_enter_verify_zp(zfsvfs, zp, FTAG)) != 0)
+ 		return (error);
+ 
+-	ASSERT3U(io_off, <, i_size);
+-
+-	if (io_off + io_len > i_size)
++	/*
++	 * If the page lies entirely at or beyond EOF (e.g. it raced a
++	 * truncate) just lock the page and let zfs_fillpage() re-check
++	 * i_size under the range lock and zero-fill it.
++	 */
++	if (io_off >= i_size)
++		io_len = PAGE_SIZE;
++	else if (io_off + io_len > i_size)
+ 		io_len = i_size - io_off;
+ 
+ 	/*

--- a/images.yaml
+++ b/images.yaml
@@ -11,7 +11,7 @@ zfs:
     linux_experimental: false
   coreos-testing:
     minor_version: "2.4"
-    linux_experimental: true
+    linux_experimental: false
 
 arch-arm-x86: &arch-arm-x86
   architecture:


### PR DESCRIPTION
## Problem

ZFS builds for `coreos-stable` have been failing since CoreOS jumped to kernel 7.1 on 2026-07-20, blocking kernel CVE fixes, nvidia driver updates, and everything else in akmods from reaching `ucore:stable` and other downstream users.

## Approach

2.4.3 can already handle 7.1 — upstream's actual compat work ([openzfs/zfs#18471](https://github.com/openzfs/zfs/pull/18471)) made the release. The only thing stopping us is one line in `META` declaring support up to 7.0. So we pick up two upstream commits:

| Patch | Upstream | Effect |
|---|---|---|
| `a35e8d8` | [#18682](https://github.com/openzfs/zfs/pull/18682) — Tony Hutter, signed-off Rob Norris | `META`: `Linux-Maximum` 7.0 → 7.1. One line, no behavior change. |
| `223b8bc` | [#18715](https://github.com/openzfs/zfs/pull/18715) — Brian Behlendorf, reviewed by Alexander Motin | Replaces a compiled-out `ASSERT3U` in `zfs_fillpage()`/`zfs_getpage()` with a real bounds check. |

The first commit lets us avoid `--enable-linux-experimental`, which floods dmesg with EXPERIMENTAL warnings that mask real errors. `coreos-testing` won't need that switch anymore either, so it's off.

The second commit is worth taking regardless of 7.1: an mmap read racing a truncate can send ZFS zeroing memory it doesn't own, and the guard that should have caught it only exists in debug builds. This may fix a memory corruption bug reported on 7.0.14, so it applies to our current users even on 7.0 kernels.

## Gating

The patches apply to 2.4.3 and nothing else — any other version and the build skips them and says so. Neither fix has landed on the 2.4 release branch (upstream hasn't tagged a release since 2026-06-12), so this turns itself off whenever 2.4.4 arrives; cleanup is deleting the patches directory and one `if` block. If a release ever ships these commits and we somehow still tried to patch, the build fails loudly rather than quietly producing something untested.

Patch files are verbatim upstream, so authorship and sign-offs travel with them.

## Testing

**Verified locally:** `just test` in the devcontainer, all exit 0, zero `EXPERIMENTAL` occurrences in any log:

| Flavor | Kernel | Result |
|---|---|---|
| coreos-stable | 7.1.4-200 | patched, compiled, signed, verified — `just build` also passed |
| coreos-testing | 7.1.5-201 | patched, compiled, signed, verified, non-experimental |
| coreos-testing | 7.0.4-200 | patched, compiled, signed, verified |
| longterm-6.18 | 6.18.42-200 | patched, compiled, signed, verified |

**Verified in CI:** all zfs jobs pass on both arches — coreos-stable 43/44, coreos-testing 44, centos 10, and longterm-6.18 44. The aarch64 legs matter here because an existing ARM-specific patch and a `raidz_test` check live in the same script; both came through clean.

No workflow regeneration needed; the `zfs:` settings are only read by the `Justfile`.
