### PR TITLE
fix(ci): remove exact Cosign version gate

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -258,7 +258,6 @@ jobs:
           set -euo pipefail
 
           cosign version
-          [[ "$(cosign version --json | jq -r '.gitVersion')" == "v3.1.2" ]]
           command -v gh
           gh --version
 


### PR DESCRIPTION
Verify published image signatures directly instead of requiring one Cosign patch version.

Follow example of https://github.com/ublue-os/main/pull/2721

I'd missed the fact that this existed both repos.