### PR TITLE
fix: Preserve cron schedule across workflow regeneration

### DIFF
--- a/.github/workflows/build-akmods-centos.yml
+++ b/.github/workflows/build-akmods-centos.yml
@@ -13,7 +13,7 @@ on:
     paths-ignore:
       - '**.md'
   schedule:
-    - cron: '25 0 * * *'   # 0025 UTC everyday
+    - cron: '25 0 * * *'  # staggered minute past 00:00 UTC, see Justfile generate-workflows
   workflow_dispatch:
 jobs:
   cache_kernel_centos_10:

--- a/.github/workflows/build-akmods-coreos-stable.yml
+++ b/.github/workflows/build-akmods-coreos-stable.yml
@@ -13,7 +13,7 @@ on:
     paths-ignore:
       - '**.md'
   schedule:
-    - cron: '19 0 * * *'  # 0019 UTC everyday
+    - cron: '19 0 * * *'  # staggered minute past 00:00 UTC, see Justfile generate-workflows
   workflow_dispatch:
 jobs:
   cache_kernel_coreos-stable_43:

--- a/.github/workflows/build-akmods-coreos-testing.yml
+++ b/.github/workflows/build-akmods-coreos-testing.yml
@@ -13,7 +13,7 @@ on:
     paths-ignore:
       - '**.md'
   schedule:
-    - cron: '07 0 * * *'  # 0007 UTC everyday
+    - cron: '07 0 * * *'  # staggered minute past 00:00 UTC, see Justfile generate-workflows
   workflow_dispatch:
 jobs:
   cache_kernel_coreos-testing_44:

--- a/.github/workflows/build-akmods-longterm-6.18.yml
+++ b/.github/workflows/build-akmods-longterm-6.18.yml
@@ -13,7 +13,7 @@ on:
     paths-ignore:
       - '**.md'
   schedule:
-    - cron: '23 0 * * *'  # 0023 UTC everyday
+    - cron: '23 0 * * *'  # staggered minute past 00:00 UTC, see Justfile generate-workflows
   workflow_dispatch:
 jobs:
   cache_kernel_longterm-6-18_44:

--- a/.github/workflows/build-akmods-main.yml
+++ b/.github/workflows/build-akmods-main.yml
@@ -13,7 +13,7 @@ on:
     paths-ignore:
       - '**.md'
   schedule:
-    - cron: '01 0 * * *'  # 0001 UTC everyday
+    - cron: '01 0 * * *'  # staggered minute past 00:00 UTC, see Justfile generate-workflows
   workflow_dispatch:
 jobs:
   cache_kernel_main_44:

--- a/.github/workflows/build-akmods-ogc-lts.yml
+++ b/.github/workflows/build-akmods-ogc-lts.yml
@@ -13,7 +13,7 @@ on:
     paths-ignore:
       - '**.md'
   schedule:
-    - cron: '16 0 * * *'  # 0016 UTC everyday
+    - cron: '16 0 * * *'  # staggered minute past 00:00 UTC, see Justfile generate-workflows
   workflow_dispatch:
 jobs:
   cache_kernel_ogc-lts_44:

--- a/.github/workflows/build-akmods-ogc.yml
+++ b/.github/workflows/build-akmods-ogc.yml
@@ -13,7 +13,7 @@ on:
     paths-ignore:
       - '**.md'
   schedule:
-    - cron: '18 0 * * *'  # 0018 UTC everyday
+    - cron: '18 0 * * *'  # staggered minute past 00:00 UTC, see Justfile generate-workflows
   workflow_dispatch:
 jobs:
   cache_kernel_ogc_43:

--- a/Justfile
+++ b/Justfile
@@ -531,6 +531,19 @@ generate-workflows:
             exit 1
         fi
 
+        # Preserve each flavor's already-assigned cron minute across regenerations so
+        # unrelated images.yaml/template edits don't produce spurious cron diffs. A
+        # flavor only gets a freshly randomized minute if it has no prior generated
+        # file (e.g. it's brand new, or a previous run was interrupted mid-rm).
+        declare -A cron_minutes=()
+        for f in ./.github/workflows/build-akmods-*.yml; do
+            [[ -e "$f" ]] || continue
+            flavor="$(basename "$f" .yml)"
+            flavor="${flavor#build-akmods-}"
+            minute=$(sed -n "s/.*cron: '\([0-9]\{1,2\}\) .*/\1/p" "$f")
+            [[ -n "$minute" ]] && cron_minutes[$flavor]="$minute"
+        done
+
         rm -f "./.github/workflows/build"*".yml"
 
         declare -A images=()
@@ -561,7 +574,8 @@ generate-workflows:
     # Generate the workflow by running `just generate-workflows` at git root
     # Modify the inputs in workflow-templates
     EOF
-            sed "s/AKMODs/${i^^} akmods/;s/05/$(printf '%02d' $(( RANDOM % 30)))/g" ./workflow-templates/workflow.yaml.in
+            minute="${cron_minutes[$i]:-$(printf '%02d' $(( RANDOM % 30 )))}"
+            sed "s/AKMODs/${i^^} akmods/;s/%%CRON_MINUTE%%/$minute/g" ./workflow-templates/workflow.yaml.in
 
             echo "jobs:"
             for j in "${!workflows[@]}"; do

--- a/README.md
+++ b/README.md
@@ -222,6 +222,20 @@ All build targets are defined in the `images.yaml` file. This is where the top l
 yq 'explode(.).images' images.yaml
 ```
 
+### Regenerating GitHub Workflows
+
+The `.github/workflows/build-akmods-*.yml` files are generated from `images.yaml` and the templates in `workflow-templates/` (`workflow.yaml.in`, `cache_kernel.yaml.in`, `job.yaml.in`, `check-status.yaml.in`) by running:
+
+```bash
+just generate-workflows
+```
+
+Run this and commit the resulting diff whenever you edit `images.yaml` (adding/removing a kernel, flavor, or target) or anything in `workflow-templates/`. Nothing in CI does this for you.
+
+Never hand-edit files under `.github/workflows/build-akmods-*.yml` directly — they're regenerated from the templates above, and manual edits will be silently discarded the next time someone runs `just generate-workflows`.
+
+Each flavor's daily build is scheduled at a staggered UTC minute assigned once and preserved across regenerations, so an unrelated `images.yaml` edit shouldn't produce cron diffs unless that flavor's generated file was missing beforehand.
+
 ### Adding Kernels and KMODs
 
 Generally speaking, Kernels are only added if they will be used internally to Universal Blue.

--- a/workflow-templates/workflow.yaml.in
+++ b/workflow-templates/workflow.yaml.in
@@ -7,5 +7,5 @@ on:
     paths-ignore:
       - '**.md'
   schedule:
-    - cron: '05 0 * * *'  # 0005 UTC everyday
+    - cron: '%%CRON_MINUTE%% 0 * * *'  # staggered minute past 00:00 UTC, see Justfile generate-workflows
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- `just generate-workflows` re-randomized every flavor's daily cron minute on every run, even when nothing about that flavor changed, so unrelated `images.yaml`/template edits produced spurious schedule diffs that had to be reverted by hand.
- Each flavor now keeps its previously-assigned cron minute across regenerations; a flavor only gets a freshly randomized minute if it doesn't have a generated workflow file yet (e.g. a brand-new flavor).
- Documents `just generate-workflows` in the README (what it does, when to run it, and the cron-preservation behavior) since this wasn't covered anywhere before.

## Test plan
- [x] Ran the fixed `generate-workflows` logic once: cron minutes for all 7 existing flavors (centos, coreos-stable, coreos-testing, longterm-6.18, main, ogc, ogc-lts) stayed the same as before the change.
- [x] Ran it again with no other changes: fully idempotent, zero diff.
- [x] Temporarily added a dummy flavor to `images.yaml` and confirmed only its new workflow file got a freshly randomized cron minute, with all existing files untouched (then reverted the test change).