### PR TITLE
fix: Fail the build when a common or nvidia kmod script fails

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -85,6 +85,7 @@ RUNEOF
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
+set ${CI+-x} -euo pipefail
 /tmp/build-kmod-framework-laptop.sh
 /tmp/build-kmod-openrazer.sh
 /tmp/build-kmod-v4l2loopback.sh
@@ -127,17 +128,20 @@ COPY build_files/nvidia /tmp/
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
+set ${CI+-x} -euo pipefail
 /tmp/build-ublue-os-nvidia-addons.sh
 cp /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons*.rpm /var/cache/rpms/ublue-os/
 RUNEOF
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
+set ${CI+-x} -euo pipefail
 /tmp/build-kmod-nvidia.sh "$KMOD_REPO"
 RUNEOF
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
+set ${CI+-x} -euo pipefail
 /tmp/download-nvidia-rpms.sh "$KMOD_REPO"
 install -m755 -t /var/cache/rpms/ublue-os /tmp/nvidia-install.sh
 RUNEOF


### PR DESCRIPTION
The `RUN` blocks that call `build-kmod-*.sh` for the `common` and `nvidia` targets ran `bash <<'RUNEOF'` without `set -euo pipefail`, unlike every other block in `Containerfile.in`. When a script exited non-zero, the remaining scripts still ran and the build went on to RPM caching and signing with a partial set of modules.

That is how #588 (Terra openrazer) broke aarch64 builds: `build-kmod-openrazer.sh` aborted before removing its repo file, and the later kmod scripts kept running with Terra still enabled, pulling x86_64 RPMs into `/var/cache/rpms/common` and failing the aarch64 test install.

This adds `set ${CI+-x} -euo pipefail` to the `common` kmod block and the three `nvidia` blocks so any failure stops the job. The `extra` block already has it and intentionally keeps going on per-kmod failures via `|| echo "SKIPPED: ..."`, so it is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)