### PR TITLE
fix: Make kmod build failures fatal and retry flaky ZFS downloads

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -85,6 +85,7 @@ RUNEOF
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
+set ${CI+-x} -euo pipefail
 /tmp/build-kmod-framework-laptop.sh
 /tmp/build-kmod-openrazer.sh
 /tmp/build-kmod-v4l2loopback.sh
@@ -127,17 +128,20 @@ COPY build_files/nvidia /tmp/
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
+set ${CI+-x} -euo pipefail
 /tmp/build-ublue-os-nvidia-addons.sh
 cp /tmp/ublue-os-nvidia-addons/rpmbuild/RPMS/noarch/ublue-os-nvidia-addons*.rpm /var/cache/rpms/ublue-os/
 RUNEOF
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
+set ${CI+-x} -euo pipefail
 /tmp/build-kmod-nvidia.sh "$KMOD_REPO"
 RUNEOF
 RUN --mount=type=cache,dst=/var/cache/dnf \
     --mount=type=cache,dst=/var/cache/libdnf5 \
     bash <<'RUNEOF'
+set ${CI+-x} -euo pipefail
 /tmp/download-nvidia-rpms.sh "$KMOD_REPO"
 install -m755 -t /var/cache/rpms/ublue-os /tmp/nvidia-install.sh
 RUNEOF

--- a/build_files/common/build-kmod-vhba.sh
+++ b/build_files/common/build-kmod-vhba.sh
@@ -6,6 +6,11 @@ ARCH="$(rpm -E '%_arch')"
 KERNEL="$(rpm -q "${KERNEL_NAME}" --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E '%fedora')"
 
+# Skip for aarch64, vhba only ships for x86_64
+if [[ "${ARCH}" =~ aarch64 ]]; then
+    exit 0
+fi
+
 cp /tmp/ublue-os-akmods-addons/rpmbuild/SOURCES/_copr_rok-cdemu.repo /etc/yum.repos.d/
 
 ### BUILD vhba (succeed or fail-fast with debug output)

--- a/build_files/zfs/build-kmod-zfs.sh
+++ b/build_files/zfs/build-kmod-zfs.sh
@@ -18,8 +18,13 @@ fi
 
 cd /tmp
 
+# GitHub's unauthenticated API rate limit (and the occasional mirror hiccup) makes
+# these fetches flaky, so retry on any transient error and fail hard on a bad
+# response instead of feeding a rate-limit page into jq.
+CURL=(curl --fail --show-error --location --retry 5 --retry-delay 5 --retry-all-errors)
+
 # Use cURL to fetch the given URL, saving the response to `data.json`
-curl "https://api.github.com/repos/openzfs/zfs/releases" -o data.json
+"${CURL[@]}" "https://api.github.com/repos/openzfs/zfs/releases" -o data.json
 ZFS_VERSION=$(jq -r --arg ZMV "zfs-${ZFS_MINOR_VERSION}" '[ .[] | select(.prerelease==false and .draft==false) | select(.tag_name | startswith($ZMV))][0].tag_name' data.json|cut -f2- -d-)
 echo "ZFS_MINOR_VERSION==$ZFS_MINOR_VERSION"
 echo "ZFS_VERSION==$ZFS_VERSION"
@@ -32,9 +37,9 @@ dnf install -y libtirpc-devel libblkid-devel libuuid-devel libudev-devel openssl
 
 ### BUILD zfs
 echo "getting zfs-${ZFS_VERSION}.tar.gz"
-curl -L -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.tar.gz"
-curl -L -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.tar.gz.asc"
-curl -L -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.sha256.asc"
+"${CURL[@]}" -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.tar.gz"
+"${CURL[@]}" -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.tar.gz.asc"
+"${CURL[@]}" -O "https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.sha256.asc"
 
 echo "Import key"
 # https://openzfs.github.io/openzfs-docs/Project%20and%20Community/Signing%20Keys.html


### PR DESCRIPTION
Two build-reliability fixes from the #588 aarch64 breakage.

- The `common` and `nvidia` kmod RUN blocks in `Containerfile.in` ran without
  `set -euo pipefail`, so a failing `build-kmod-*.sh` was swallowed and the
  build kept going into caching and signing with a partial module set. Now any
  failure stops the job. The `extra` block is left alone; it already tolerates per-kmod
  failures.
- `build-kmod-zfs.sh` hit the GitHub API with a bare `curl`. When throttled it
  fed the rate-limit page to `jq`, which failed with a useless error (run
  33564594444). All four downloads now use
  `curl --fail --retry 5 --retry-delay 5 --retry-all-errors`.
